### PR TITLE
feat: Add task status toggle with click interaction

### DIFF
--- a/src/app/api/tasks/[taskId]/route.ts
+++ b/src/app/api/tasks/[taskId]/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+const projectsDirectory = path.join(process.cwd(), "content/projects");
+
+interface UpdateTaskStatusRequest {
+  projectSlug: string;
+  status: "todo" | "in_progress" | "done" | "blocked";
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ taskId: string }> }
+) {
+  try {
+    const { taskId } = await params;
+    const body: UpdateTaskStatusRequest = await request.json();
+    const { projectSlug, status } = body;
+
+    if (!projectSlug || !status || !taskId) {
+      return NextResponse.json(
+        { error: "Missing required fields: projectSlug, status, taskId" },
+        { status: 400 }
+      );
+    }
+
+    const validStatuses = ["todo", "in_progress", "done", "blocked"];
+    if (!validStatuses.includes(status)) {
+      return NextResponse.json(
+        { error: `Invalid status. Must be one of: ${validStatuses.join(", ")}` },
+        { status: 400 }
+      );
+    }
+
+    const tasksPath = path.join(projectsDirectory, projectSlug, "tasks.md");
+
+    if (!fs.existsSync(tasksPath)) {
+      return NextResponse.json(
+        { error: "Tasks file not found" },
+        { status: 404 }
+      );
+    }
+
+    // Read the file
+    let content = fs.readFileSync(tasksPath, "utf8");
+    const { data: frontmatter, content: markdownContent } = matter(content);
+
+    // Find and replace the status for the specific task
+    // Pattern: - **id:** task-001 followed by - **status:** <status>
+    const taskIdPattern = new RegExp(
+      `(- \\*\\*id:\\*\\* ${taskId}\\n- \\*\\*status:\\*\\* )(\\w+)`,
+      "g"
+    );
+
+    const updatedMarkdown = markdownContent.replace(taskIdPattern, `$1${status}`);
+
+    if (updatedMarkdown === markdownContent) {
+      return NextResponse.json(
+        { error: `Task ${taskId} not found` },
+        { status: 404 }
+      );
+    }
+
+    // Update the updated_at date in frontmatter
+    frontmatter.updated_at = new Date().toISOString().split("T")[0];
+
+    // Reconstruct the file
+    const newContent = matter.stringify(updatedMarkdown, frontmatter);
+    fs.writeFileSync(tasksPath, newContent, "utf8");
+
+    return NextResponse.json({
+      success: true,
+      taskId,
+      newStatus: status,
+      updatedAt: frontmatter.updated_at,
+    });
+  } catch (error) {
+    console.error("Error updating task status:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -145,7 +145,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
             </h2>
           </div>
 
-          <TaskList tasks={tasks.items} />
+          <TaskList tasks={tasks.items} projectSlug={slug} />
         </div>
       </div>
     </div>

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -7,11 +7,12 @@ import { TaskItem } from "./task-item";
 
 interface TaskListProps {
   tasks: Task[];
+  projectSlug: string;
 }
 
 type FilterStatus = "all" | "todo" | "in_progress" | "done" | "blocked";
 
-export function TaskList({ tasks }: TaskListProps) {
+export function TaskList({ tasks, projectSlug }: TaskListProps) {
   const [filter, setFilter] = useState<FilterStatus>("all");
 
   const filteredTasks = filter === "all"
@@ -52,7 +53,7 @@ export function TaskList({ tasks }: TaskListProps) {
       {/* Task list */}
       <div className="space-y-4">
         {filteredTasks.map((task) => (
-          <TaskItem key={task.id} task={task} />
+          <TaskItem key={task.id} task={task} projectSlug={projectSlug} />
         ))}
 
         {filteredTasks.length === 0 && (


### PR DESCRIPTION
## Summary

Adds interactive task status toggling - click the status icon to cycle through statuses.

## Changes

- **API Route**: `PATCH /api/tasks/[taskId]` - Updates task status in the markdown file
- **TaskItem**: Clickable status icon with hover effects
- **Status Cycle**: todo → in_progress → done → blocked → todo
- **Optimistic Updates**: UI updates immediately, rolls back on error

## Demo

Click the status icon (○, ◐, ✓, ✕) on any task to cycle through statuses. Changes persist to the markdown file.

## Testing

- [x] Build passes
- [x] Status cycles correctly
- [x] Changes persist after page refresh