### PR TITLE
feat(docs): branding update and shared ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,27 +137,18 @@ BlueprintAI is designed to work seamlessly with AI coding assistants. See [AGENT
 
 ```
 blueprint-ai/
+├── apps/
+│   ├── web/                   # Next.js App Router (Main App)
+│   └── docs/                  # Fumadocs Documentation Site
+├── packages/
+│   ├── ui/                    # Shared UI components
+│   ├── schemas/               # Shared Zod schemas
+│   ├── utils/                 # Shared utilities
+│   ├── tsconfig/              # Shared TypeScript configs
+│   └── eslint-config/         # Shared ESLint configs
 ├── content/
-│   └── projects/              # Your projects live here
-│       └── example-project/
-│           ├── prd.md         # Product Requirements Document
-│           └── tasks.md       # Tasks derived from PRD
-├── src/
-│   ├── app/                   # Next.js App Router
-│   │   ├── layout.tsx         # Root layout with sidebar
-│   │   ├── page.tsx           # Dashboard page
-│   │   └── projects/[slug]/   # Dynamic project pages
-│   ├── components/            # React components
-│   │   ├── sidebar.tsx        # Navigation sidebar
-│   │   ├── project-card.tsx   # Project card for dashboard
-│   │   ├── task-list.tsx      # Task list with filters
-│   │   └── task-item.tsx      # Individual task with subtasks
-│   └── lib/
-│       ├── schemas.ts         # Zod validation schemas
-│       ├── markdown.ts        # Markdown parsing utilities
-│       └── utils.ts           # General utilities
-├── AGENTS.md                  # Instructions for AI agents
-└── package.json
+│   └── projects/              # User projects (PRDs & Tasks)
+└── AGENTS.md                  # Instructions for AI agents
 ```
 
 ## 🛠️ Tech Stack

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -2,15 +2,49 @@ import Link from 'next/link';
 
 export default function HomePage() {
   return (
-    <div className="flex flex-col justify-center text-center flex-1">
-      <h1 className="text-2xl font-bold mb-4">Hello World</h1>
-      <p>
-        You can open{' '}
-        <Link href="/docs" className="font-medium underline">
-          /docs
-        </Link>{' '}
-        and see the documentation.
+    <main className="flex flex-1 flex-col justify-center text-center">
+      <h1 className="mb-4 text-4xl font-bold">BlueprintAI</h1>
+      <p className="mb-8 text-lg text-muted-foreground">
+        Intelligent Task Management System designed for Agents and Humans.
       </p>
-    </div>
+      
+      <div className="flex justify-center gap-4 mb-16">
+        <Link 
+          href="/docs" 
+          className="rounded-full bg-foreground text-background px-6 py-3 font-medium transition-colors hover:bg-muted-foreground"
+        >
+          Get Started
+        </Link>
+        <a 
+          href="https://github.com/josias-junior/blueprint-ai" 
+          target="_blank" 
+          rel="noreferrer"
+          className="rounded-full border border-border px-6 py-3 font-medium transition-colors hover:bg-muted"
+        >
+          GitHub
+        </a>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto px-4 text-left">
+        <div className="p-6 rounded-lg border bg-card text-card-foreground">
+          <h3 className="font-semibold text-xl mb-2">Designed for Agents</h3>
+          <p className="text-muted-foreground">
+            Generate PRDs and Tasks using standard Markdown. A simple interface ideal for LLMs.
+          </p>
+        </div>
+        <div className="p-6 rounded-lg border bg-card text-card-foreground">
+          <h3 className="font-semibold text-xl mb-2">Built for Humans</h3>
+          <p className="text-muted-foreground">
+            Rich, interactive interfaces that parse agent-generated files into a premium UI experience.
+          </p>
+        </div>
+        <div className="p-6 rounded-lg border bg-card text-card-foreground">
+          <h3 className="font-semibold text-xl mb-2">Bridge to Enterprise</h3>
+          <p className="text-muted-foreground">
+            Designed to integrate with enterprise systems like Jira and Linear, closing the loop.
+          </p>
+        </div>
+      </div>
+    </main>
   );
 }

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -16,7 +16,7 @@ export default function HomePage() {
           Get Started
         </Link>
         <a 
-          href="https://github.com/josias-junior/blueprint-ai" 
+          href="https://github.com/1001Josias/blueprint-ai" 
           target="_blank" 
           rel="noreferrer"
           className="rounded-full border border-border px-6 py-3 font-medium transition-colors hover:bg-muted"

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -15,40 +15,8 @@ BlueprintAI was architected with a specific vision: **Bridging the gap between A
 - **Built for Humans**: While agents speak Markdown, humans prefer rich, interactive interfaces. BlueprintAI parses these agent-generated files to render a **premium, user-friendly UI**, providing a seamless experience for tracking progress, managing priorities, and visualizing project status.
 - **Bridge to Enterprise**: BlueprintAI isn't just a local sandbox. We are designing native integrations to seamlessly transform your local tasks into deliverables within your company's task management systems (like Jira, Linear, or Asana), closing the loop between AI planning and enterprise execution.
 
-## Quick Start
+> [!NOTE]
+> Are you a developer looking to contribute? Check out our [README](https://github.com/josias-junior/blueprint-ai) and [AGENTS.md](https://github.com/josias-junior/blueprint-ai/blob/main/AGENTS.md) for technical architecture and setup instructions.
 
-### Prerequisites
 
-- Node.js 18+
-- pnpm 8+
 
-### Installation
-
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/josias-junior/blueprint-ai.git
-   ```
-
-2. Install dependencies:
-   ```bash
-   pnpm install
-   ```
-
-3. Start the development server:
-   ```bash
-   pnpm dev
-   ```
-
-The application will be available at:
-- Web App: [http://localhost:3000](http://localhost:3000)
-- Documentation: [http://localhost:3001](http://localhost:3001)
-
-## Architecture
-
-BlueprintAI is built as a monorepo using **Turborepo**, containing:
-
-- **apps/web**: Next.js 16 Web Application (App Router)
-- **apps/docs**: Fumadocs Documentation Site
-- **packages/schemas**: Shared Zod schemas and types
-- **packages/utils**: Shared utility functions
-- **packages/ui**: Shared UI components

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -16,7 +16,7 @@ BlueprintAI was architected with a specific vision: **Bridging the gap between A
 - **Bridge to Enterprise**: BlueprintAI isn't just a local sandbox. We are designing native integrations to seamlessly transform your local tasks into deliverables within your company's task management systems (like Jira, Linear, or Asana), closing the loop between AI planning and enterprise execution.
 
 > [!NOTE]
-> Are you a developer looking to contribute? Check out our [README](https://github.com/josias-junior/blueprint-ai) and [AGENTS.md](https://github.com/josias-junior/blueprint-ai/blob/main/AGENTS.md) for technical architecture and setup instructions.
+> Are you a developer looking to contribute? Check out our [README](https://github.com/1001Josias/blueprint-ai) and [AGENTS.md](https://github.com/1001Josias/blueprint-ai/blob/main/AGENTS.md) for technical architecture and setup instructions.
 
 
 

--- a/apps/docs/content/docs/resources/agents.mdx
+++ b/apps/docs/content/docs/resources/agents.mdx
@@ -1,5 +1,5 @@
 ---
-title: Agents Config
+title: Agents Guide
 description: Configuration and Guidelines for AI Agents
 ---
 

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -3,7 +3,7 @@ import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 export function baseOptions(): BaseLayoutProps {
   return {
     nav: {
-      title: 'My App',
+      title: 'BlueprintAI',
     },
   };
 }

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -1,9 +1,16 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 
+import { Logo } from '@repo/ui';
+
 export function baseOptions(): BaseLayoutProps {
   return {
     nav: {
-      title: 'BlueprintAI',
+      title: (
+        <>
+          <Logo width={24} height={24} className="text-foreground" />
+          <span className="font-semibold ml-2">BlueprintAI</span>
+        </>
+      ),
     },
   };
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@repo/ui": "workspace:^",
     "fumadocs-core": "16.4.1",
     "fumadocs-mdx": "14.2.3",
     "fumadocs-ui": "16.4.1",
@@ -25,10 +26,10 @@
     "@types/node": "^24.10.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
+    "eslint": "^9.39.2",
+    "eslint-config-next": "16.0.10",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3",
-    "eslint-config-next": "16.0.10",
-    "eslint": "^9.39.2"
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@repo/ui",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.tsx",
+  "types": "./src/index.tsx",
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "lucide-react": "^0.454.0"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@repo/eslint-config": "workspace:*",
+    "@types/react": "^19.0.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,0 +1,1 @@
+export * from './logo';

--- a/packages/ui/src/logo.tsx
+++ b/packages/ui/src/logo.tsx
@@ -1,0 +1,43 @@
+import type { SVGProps } from 'react';
+
+export function Logo(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg 
+      width="80" 
+      height="80" 
+      viewBox="0 0 80 80" 
+      fill="none" 
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <rect width="80" height="80" rx="16" fill="url(#gradient-logo)" />
+      <path 
+        d="M24 28H56M24 40H48M24 52H40" 
+        stroke="white" 
+        strokeWidth="4" 
+        strokeLinecap="round" 
+      />
+      <circle cx="56" cy="52" r="8" fill="white" fillOpacity="0.9" />
+      <path 
+        d="M54 52L55.5 53.5L58.5 50.5" 
+        stroke="#8B5CF6" 
+        strokeWidth="2" 
+        strokeLinecap="round" 
+        strokeLinejoin="round" 
+      />
+      <defs>
+        <linearGradient 
+          id="gradient-logo" 
+          x1="0" 
+          y1="0" 
+          x2="80" 
+          y2="80" 
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#8B5CF6" />
+          <stop offset="1" stopColor="#7C3AED" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   apps/docs:
     dependencies:
+      '@repo/ui':
+        specifier: workspace:^
+        version: link:../../packages/ui
       fumadocs-core:
         specifier: 16.4.1
         version: 16.4.1(@types/react@19.2.7)(lucide-react@0.561.0(react@19.2.3))(next@16.0.10(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5)
@@ -175,6 +178,28 @@ importers:
         version: 4.1.18
 
   packages/tsconfig: {}
+
+  packages/ui:
+    dependencies:
+      lucide-react:
+        specifier: ^0.454.0
+        version: 0.454.0(react@19.2.3)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.3
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.7
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
 
   packages/utils:
     dependencies:
@@ -2733,6 +2758,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.454.0:
+    resolution: {integrity: sha512-hw7zMDwykCLnEzgncEEjHeA6+45aeEzRYuKHuyRSOPkhko+J3ySGjGIzu+mmMfDFG1vazHepMaYFYHbTFAZAAQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
   lucide-react@0.561.0:
     resolution: {integrity: sha512-Y59gMY38tl4/i0qewcqohPdEbieBy7SovpBL9IFebhc2mDd8x4PZSOsiFRkpPcOq6bj1r/mjH/Rk73gSlIJP2A==}
@@ -6407,6 +6437,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.454.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   lucide-react@0.561.0(react@19.2.3):
     dependencies:

--- a/projects/documentation-site/tasks.md
+++ b/projects/documentation-site/tasks.md
@@ -34,7 +34,7 @@ Adjust Tailwind colors to use BlueprintAI's violet/dark theme.
 
 ### Subtasks
 
-#### [ ] Migrate Getting Started
+#### [x] Migrate Getting Started
 Create `content/docs/index.mdx` page with introduction and setup (based on README).
 
 #### [ ] Create "Core Concepts" Guide
@@ -56,7 +56,7 @@ Document endpoints like `PATCH /api/tasks/[taskId]` using OpenAPI or manual MDX.
 
 ### Subtasks
 
-#### [ ] Configure Search
+#### [x] Configure Search
 Verify indexing and functionality of Fumadocs search.
 
 #### [ ] SEO Review

--- a/projects/documentation-site/tasks.md
+++ b/projects/documentation-site/tasks.md
@@ -37,13 +37,13 @@ Adjust Tailwind colors to use BlueprintAI's violet/dark theme.
 #### [x] Migrate Getting Started
 Create `content/docs/index.mdx` page with introduction and setup (based on README).
 
-#### [ ] Create "Core Concepts" Guide
+#### [x] Create "Core Concepts" Guide
 Document PRD -> Tasks flow and `projects/` directory structure.
 
-#### [ ] Create Schema Reference
+#### [x] Create Schema Reference
 Document Zod schemas and frontmatter (based on `AGENTS.md`) using TypeTable if possible.
 
-#### [ ] Create API Guide
+#### [x] Create API Guide
 Document endpoints like `PATCH /api/tasks/[taskId]` using OpenAPI or manual MDX.
 
 ---


### PR DESCRIPTION
Updates documentation branding, creates shared UI package, and refines documentation scope.

## Changes
- Branding: Updated Homepage, Site Title, and Logo.
- Architecture: Created `@repo/ui` for shared components.
- Content: Renamed 'Agents Guide', refined user docs vs technical docs scope.
- Fix: Updated `README.md` to reflect Monorepo structure.