### PR TITLE
fix(prd): restore missing id field in state-management frontmatter

### DIFF
--- a/projects/blueprint-ai/state-management/prd.md
+++ b/projects/blueprint-ai/state-management/prd.md
@@ -1,4 +1,5 @@
 ---
+id: state-management
 title: State Management Improvements
 status: draft
 version: "1.0"


### PR DESCRIPTION
## Summary

Restores the accidentally removed `id` field in the state-management PRD frontmatter.

## Problem

The `id: state-management` field was accidentally removed from `prd.md`, causing Zod validation to fail with the error:
```
TypeError: Cannot set property message of [object Object] which has only a getter
```

This crashed the entire app with a 500 error on all pages.

## Solution

Restored the missing `id` field in the frontmatter:
```diff
---
+id: state-management
title: State Management Improvements
```

## Testing

- [x] App loads successfully (200 response)
- [x] TypeScript compiles without errors