### PR TITLE
feat(nav-102): Add Dashboard Views (Today, Upcoming, Calendar, Reports)

### DIFF
--- a/apps/web/src/app/calendar/calendar-content.tsx
+++ b/apps/web/src/app/calendar/calendar-content.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { useState } from "react";
+import { TaskWithProject } from "@/lib/markdown";
+import { TaskDetailModal } from "@/components/task-detail-modal";
+import { useTaskIdParam } from "@/lib/search-params";
+import { cn } from "@/lib/utils";
+
+interface CalendarPageProps {
+  tasks: TaskWithProject[];
+}
+
+function CalendarContent({ tasks }: CalendarPageProps) {
+  const [selectedTaskId, setSelectedTaskId] = useTaskIdParam();
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+
+  // Get calendar data
+  const firstDayOfMonth = new Date(year, month, 1);
+  const lastDayOfMonth = new Date(year, month + 1, 0);
+  const startDay = firstDayOfMonth.getDay();
+  const daysInMonth = lastDayOfMonth.getDate();
+
+  // Create calendar grid
+  const calendarDays: (number | null)[] = [];
+  for (let i = 0; i < startDay; i++) {
+    calendarDays.push(null);
+  }
+  for (let i = 1; i <= daysInMonth; i++) {
+    calendarDays.push(i);
+  }
+
+  // Tasks by date
+  const tasksByDate = tasks.reduce(
+    (acc, task) => {
+      if (task.dueDate) {
+        if (!acc[task.dueDate]) {
+          acc[task.dueDate] = [];
+        }
+        acc[task.dueDate].push(task);
+      }
+      return acc;
+    },
+    {} as Record<string, TaskWithProject[]>
+  );
+
+  const getDateString = (day: number) => {
+    return `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+  };
+
+  const isToday = (day: number) => {
+    const today = new Date();
+    return (
+      today.getFullYear() === year &&
+      today.getMonth() === month &&
+      today.getDate() === day
+    );
+  };
+
+  const selectedDateTasks = selectedDate ? tasksByDate[selectedDate] || [] : [];
+  const selectedTask = tasks.find((t) => t.id === selectedTaskId);
+
+  const priorityColors = {
+    low: "bg-slate-500",
+    medium: "bg-blue-500",
+    high: "bg-orange-500",
+    critical: "bg-red-500",
+  };
+
+  const statusColors = {
+    todo: "bg-slate-500",
+    in_progress: "bg-yellow-500",
+    done: "bg-green-500",
+    blocked: "bg-red-500",
+  };
+
+  const navigateMonth = (delta: number) => {
+    setCurrentDate(new Date(year, month + delta, 1));
+    setSelectedDate(null);
+  };
+
+  const monthNames = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+  ];
+
+  const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+  return (
+    <div className="p-8">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-2">
+          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center">
+            <svg
+              className="w-5 h-5 text-white"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold text-white">Calendar</h1>
+            <p className="text-slate-400">Visual overview of task due dates</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        {/* Calendar Grid */}
+        <div className="lg:col-span-2">
+          <div className="rounded-2xl bg-slate-800/50 border border-slate-700/50 overflow-hidden">
+            {/* Month Navigation */}
+            <div className="flex items-center justify-between p-4 border-b border-slate-700/50">
+              <button
+                onClick={() => navigateMonth(-1)}
+                className="p-2 rounded-lg hover:bg-slate-700/50 transition-colors"
+              >
+                <svg
+                  className="w-5 h-5 text-slate-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 19l-7-7 7-7"
+                  />
+                </svg>
+              </button>
+              <h2 className="text-lg font-semibold text-white">
+                {monthNames[month]} {year}
+              </h2>
+              <button
+                onClick={() => navigateMonth(1)}
+                className="p-2 rounded-lg hover:bg-slate-700/50 transition-colors"
+              >
+                <svg
+                  className="w-5 h-5 text-slate-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            {/* Day Headers */}
+            <div className="grid grid-cols-7 border-b border-slate-700/50">
+              {dayNames.map((day) => (
+                <div
+                  key={day}
+                  className="p-3 text-center text-xs font-medium text-slate-500 uppercase"
+                >
+                  {day}
+                </div>
+              ))}
+            </div>
+
+            {/* Calendar Days */}
+            <div className="grid grid-cols-7">
+              {calendarDays.map((day, index) => {
+                if (day === null) {
+                  return (
+                    <div
+                      key={`empty-${index}`}
+                      className="p-3 min-h-[80px] border-b border-r border-slate-700/30"
+                    />
+                  );
+                }
+
+                const dateStr = getDateString(day);
+                const dayTasks = tasksByDate[dateStr] || [];
+                const isSelected = selectedDate === dateStr;
+
+                return (
+                  <button
+                    key={day}
+                    onClick={() => setSelectedDate(dateStr)}
+                    className={cn(
+                      "p-3 min-h-[80px] border-b border-r border-slate-700/30 text-left transition-all hover:bg-slate-700/30",
+                      isSelected && "bg-violet-500/20 ring-1 ring-violet-500/50",
+                      isToday(day) && !isSelected && "bg-slate-700/30"
+                    )}
+                  >
+                    <div
+                      className={cn(
+                        "text-sm font-medium mb-1",
+                        isToday(day) ? "text-violet-400" : "text-slate-300"
+                      )}
+                    >
+                      {day}
+                    </div>
+                    {dayTasks.length > 0 && (
+                      <div className="flex flex-wrap gap-1">
+                        {dayTasks.slice(0, 3).map((task) => (
+                          <div
+                            key={task.id}
+                            className={cn(
+                              "w-2 h-2 rounded-full",
+                              priorityColors[task.priority]
+                            )}
+                          />
+                        ))}
+                        {dayTasks.length > 3 && (
+                          <span className="text-[10px] text-slate-500">
+                            +{dayTasks.length - 3}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Legend */}
+          <div className="mt-4 flex items-center gap-4 text-xs text-slate-500">
+            <span className="flex items-center gap-1.5">
+              <div className="w-2 h-2 rounded-full bg-slate-500" />
+              Low
+            </span>
+            <span className="flex items-center gap-1.5">
+              <div className="w-2 h-2 rounded-full bg-blue-500" />
+              Medium
+            </span>
+            <span className="flex items-center gap-1.5">
+              <div className="w-2 h-2 rounded-full bg-orange-500" />
+              High
+            </span>
+            <span className="flex items-center gap-1.5">
+              <div className="w-2 h-2 rounded-full bg-red-500" />
+              Critical
+            </span>
+          </div>
+        </div>
+
+        {/* Selected Date Tasks */}
+        <div className="lg:col-span-1">
+          <div className="sticky top-8 rounded-2xl bg-slate-800/50 border border-slate-700/50 overflow-hidden">
+            <div className="p-4 border-b border-slate-700/50">
+              <h3 className="font-semibold text-white">
+                {selectedDate
+                  ? new Date(selectedDate + "T12:00:00").toLocaleDateString(
+                      "en-US",
+                      {
+                        weekday: "long",
+                        month: "short",
+                        day: "numeric",
+                      }
+                    )
+                  : "Select a date"}
+              </h3>
+            </div>
+            <div className="p-4 max-h-[400px] overflow-y-auto">
+              {selectedDate ? (
+                selectedDateTasks.length > 0 ? (
+                  <div className="space-y-2">
+                    {selectedDateTasks.map((task) => (
+                      <button
+                        key={task.id}
+                        onClick={() => setSelectedTaskId(task.id)}
+                        className="w-full text-left p-3 rounded-xl bg-slate-700/50 hover:bg-slate-700 transition-all group"
+                      >
+                        <div className="flex items-center gap-2 mb-1">
+                          <div
+                            className={cn(
+                              "w-2 h-2 rounded-full",
+                              statusColors[task.status]
+                            )}
+                          />
+                          <span className="text-sm font-medium text-white truncate group-hover:text-violet-300">
+                            {task.title}
+                          </span>
+                        </div>
+                        <p className="text-xs text-slate-500 truncate pl-4">
+                          {task.projectTitle}
+                        </p>
+                      </button>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-slate-500 text-center py-8">
+                    No tasks due on this date
+                  </p>
+                )
+              ) : (
+                <p className="text-sm text-slate-500 text-center py-8">
+                  Click a date to see tasks
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Task Detail Modal */}
+      {selectedTask && (
+        <TaskDetailModal
+          task={selectedTask}
+          workspace={selectedTask.workspace}
+          projectSlug={selectedTask.projectSlug}
+          onClose={() => setSelectedTaskId(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+export default function CalendarPageWrapper({
+  tasks,
+}: {
+  tasks: TaskWithProject[];
+}) {
+  return <CalendarContent tasks={tasks} />;
+}

--- a/apps/web/src/app/calendar/page.tsx
+++ b/apps/web/src/app/calendar/page.tsx
@@ -1,0 +1,8 @@
+import { getAllTasksWithProject } from "@/lib/markdown";
+import CalendarPageWrapper from "./calendar-content";
+
+export default async function CalendarPage() {
+  const tasks = await getAllTasksWithProject();
+
+  return <CalendarPageWrapper tasks={tasks} />;
+}

--- a/apps/web/src/app/reports/page.tsx
+++ b/apps/web/src/app/reports/page.tsx
@@ -1,0 +1,12 @@
+import { getAllTasksWithProject } from "@/lib/markdown";
+import { getAllProjects } from "@/lib/markdown";
+import ReportsPageWrapper from "./reports-content";
+
+export default async function ReportsPage() {
+  const [tasks, projects] = await Promise.all([
+    getAllTasksWithProject(),
+    getAllProjects(),
+  ]);
+
+  return <ReportsPageWrapper tasks={tasks} projects={projects} />;
+}

--- a/apps/web/src/app/reports/reports-content.tsx
+++ b/apps/web/src/app/reports/reports-content.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { TaskWithProject } from "@/lib/markdown";
+import { ProjectSummary } from "@/lib/schemas";
+
+interface ReportsPageProps {
+  tasks: TaskWithProject[];
+  projects: ProjectSummary[];
+}
+
+function ReportsContent({ tasks, projects }: ReportsPageProps) {
+  // Calculate stats
+  const totalTasks = tasks.length;
+  const completedTasks = tasks.filter((t) => t.status === "done").length;
+  const inProgressTasks = tasks.filter((t) => t.status === "in_progress").length;
+  const todoTasks = tasks.filter((t) => t.status === "todo").length;
+  const blockedTasks = tasks.filter((t) => t.status === "blocked").length;
+
+  const completionRate = totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0;
+
+  // Tasks by priority
+  const priorityCounts = {
+    critical: tasks.filter((t) => t.priority === "critical").length,
+    high: tasks.filter((t) => t.priority === "high").length,
+    medium: tasks.filter((t) => t.priority === "medium").length,
+    low: tasks.filter((t) => t.priority === "low").length,
+  };
+
+  // Tasks by workspace
+  const tasksByWorkspace = tasks.reduce(
+    (acc, task) => {
+      if (!acc[task.workspace]) {
+        acc[task.workspace] = 0;
+      }
+      acc[task.workspace]++;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
+
+  // Top projects by incomplete tasks
+  const projectTaskCounts = tasks.reduce(
+    (acc, task) => {
+      if (task.status !== "done") {
+        const key = `${task.workspace}/${task.projectSlug}`;
+        if (!acc[key]) {
+          acc[key] = { title: task.projectTitle, count: 0 };
+        }
+        acc[key].count++;
+      }
+      return acc;
+    },
+    {} as Record<string, { title: string; count: number }>
+  );
+
+  const topProjects = Object.entries(projectTaskCounts)
+    .sort(([, a], [, b]) => b.count - a.count)
+    .slice(0, 5);
+
+  const statusColors = {
+    done: "from-green-500 to-emerald-500",
+    in_progress: "from-yellow-500 to-orange-500",
+    todo: "from-slate-500 to-slate-600",
+    blocked: "from-red-500 to-rose-500",
+  };
+
+  const priorityColors = {
+    critical: "bg-red-500",
+    high: "bg-orange-500",
+    medium: "bg-blue-500",
+    low: "bg-slate-500",
+  };
+
+  // Calculate max for bar scaling
+  const maxPriority = Math.max(...Object.values(priorityCounts));
+  const maxWorkspace = Math.max(...Object.values(tasksByWorkspace));
+
+  return (
+    <div className="p-8">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-2">
+          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-emerald-500 to-teal-500 flex items-center justify-center">
+            <svg
+              className="w-5 h-5 text-white"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+              />
+            </svg>
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold text-white">Reports</h1>
+            <p className="text-slate-400">Analytics and insights across all projects</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Overview Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4 mb-8">
+        <div className="p-5 rounded-xl bg-gradient-to-br from-violet-600/20 to-purple-600/20 border border-violet-500/20">
+          <div className="text-3xl font-bold text-white mb-1">{totalTasks}</div>
+          <div className="text-sm text-violet-300">Total Tasks</div>
+        </div>
+        <div className="p-5 rounded-xl bg-gradient-to-br from-green-600/20 to-emerald-600/20 border border-green-500/20">
+          <div className="text-3xl font-bold text-white mb-1">{completedTasks}</div>
+          <div className="text-sm text-green-300">Completed</div>
+        </div>
+        <div className="p-5 rounded-xl bg-gradient-to-br from-yellow-600/20 to-orange-600/20 border border-yellow-500/20">
+          <div className="text-3xl font-bold text-white mb-1">{inProgressTasks}</div>
+          <div className="text-sm text-yellow-300">In Progress</div>
+        </div>
+        <div className="p-5 rounded-xl bg-gradient-to-br from-slate-600/20 to-slate-700/20 border border-slate-500/20">
+          <div className="text-3xl font-bold text-white mb-1">{todoTasks}</div>
+          <div className="text-sm text-slate-300">To Do</div>
+        </div>
+        <div className="p-5 rounded-xl bg-gradient-to-br from-red-600/20 to-rose-600/20 border border-red-500/20">
+          <div className="text-3xl font-bold text-white mb-1">{blockedTasks}</div>
+          <div className="text-sm text-red-300">Blocked</div>
+        </div>
+      </div>
+
+      {/* Charts Grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+        {/* Completion Rate */}
+        <div className="rounded-2xl bg-slate-800/50 border border-slate-700/50 p-6">
+          <h3 className="text-lg font-semibold text-white mb-4">Completion Rate</h3>
+          <div className="flex items-center gap-6">
+            <div className="relative w-32 h-32">
+              <svg className="w-32 h-32 -rotate-90" viewBox="0 0 100 100">
+                <circle
+                  cx="50"
+                  cy="50"
+                  r="40"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="12"
+                  className="text-slate-700"
+                />
+                <circle
+                  cx="50"
+                  cy="50"
+                  r="40"
+                  fill="none"
+                  stroke="url(#gradient)"
+                  strokeWidth="12"
+                  strokeLinecap="round"
+                  strokeDasharray={`${completionRate * 2.51} 251`}
+                />
+                <defs>
+                  <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+                    <stop offset="0%" stopColor="#8b5cf6" />
+                    <stop offset="100%" stopColor="#a855f7" />
+                  </linearGradient>
+                </defs>
+              </svg>
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span className="text-2xl font-bold text-white">{completionRate}%</span>
+              </div>
+            </div>
+            <div className="flex-1 space-y-3">
+              {(["done", "in_progress", "todo", "blocked"] as const).map((status) => {
+                const count =
+                  status === "done"
+                    ? completedTasks
+                    : status === "in_progress"
+                      ? inProgressTasks
+                      : status === "todo"
+                        ? todoTasks
+                        : blockedTasks;
+                const percentage = totalTasks > 0 ? Math.round((count / totalTasks) * 100) : 0;
+                return (
+                  <div key={status} className="flex items-center gap-2">
+                    <div
+                      className={`w-3 h-3 rounded-full bg-gradient-to-r ${statusColors[status]}`}
+                    />
+                    <span className="text-sm text-slate-400 capitalize flex-1">
+                      {status.replace("_", " ")}
+                    </span>
+                    <span className="text-sm text-white font-medium">{count}</span>
+                    <span className="text-xs text-slate-500 w-10 text-right">{percentage}%</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* Priority Distribution */}
+        <div className="rounded-2xl bg-slate-800/50 border border-slate-700/50 p-6">
+          <h3 className="text-lg font-semibold text-white mb-4">Priority Distribution</h3>
+          <div className="space-y-4">
+            {(["critical", "high", "medium", "low"] as const).map((priority) => {
+              const count = priorityCounts[priority];
+              const percentage = maxPriority > 0 ? (count / maxPriority) * 100 : 0;
+              return (
+                <div key={priority}>
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-sm text-slate-300 capitalize">{priority}</span>
+                    <span className="text-sm text-white font-medium">{count}</span>
+                  </div>
+                  <div className="w-full h-2 bg-slate-700 rounded-full overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all duration-500 ${priorityColors[priority]}`}
+                      style={{ width: `${percentage}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom Row */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Tasks by Workspace */}
+        <div className="rounded-2xl bg-slate-800/50 border border-slate-700/50 p-6">
+          <h3 className="text-lg font-semibold text-white mb-4">Tasks by Workspace</h3>
+          {Object.keys(tasksByWorkspace).length > 0 ? (
+            <div className="space-y-4">
+              {Object.entries(tasksByWorkspace)
+                .sort(([, a], [, b]) => b - a)
+                .map(([workspace, count]) => {
+                  const percentage = maxWorkspace > 0 ? (count / maxWorkspace) * 100 : 0;
+                  return (
+                    <div key={workspace}>
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="text-sm text-slate-300 capitalize">{workspace}</span>
+                        <span className="text-sm text-white font-medium">{count}</span>
+                      </div>
+                      <div className="w-full h-2 bg-slate-700 rounded-full overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-gradient-to-r from-violet-500 to-purple-500 transition-all duration-500"
+                          style={{ width: `${percentage}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+            </div>
+          ) : (
+            <p className="text-sm text-slate-500 text-center py-8">No workspace data available</p>
+          )}
+        </div>
+
+        {/* Top Projects by Activity */}
+        <div className="rounded-2xl bg-slate-800/50 border border-slate-700/50 p-6">
+          <h3 className="text-lg font-semibold text-white mb-4">Top Projects (Pending Tasks)</h3>
+          {topProjects.length > 0 ? (
+            <div className="space-y-3">
+              {topProjects.map(([key, { title, count }], index) => (
+                <div
+                  key={key}
+                  className="flex items-center gap-3 p-3 rounded-xl bg-slate-700/30"
+                >
+                  <div className="w-6 h-6 rounded-full bg-slate-700 flex items-center justify-center text-xs text-slate-400 font-medium">
+                    {index + 1}
+                  </div>
+                  <span className="flex-1 text-sm text-white truncate">{title}</span>
+                  <span className="text-sm text-violet-400 font-medium">{count} tasks</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-slate-500 text-center py-8">All tasks are completed! 🎉</p>
+          )}
+        </div>
+      </div>
+
+      {/* Projects Summary */}
+      <div className="mt-8 rounded-2xl bg-slate-800/50 border border-slate-700/50 p-6">
+        <h3 className="text-lg font-semibold text-white mb-4">Projects Summary</h3>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="p-4 rounded-xl bg-slate-700/30">
+            <div className="text-2xl font-bold text-white mb-1">{projects.length}</div>
+            <div className="text-sm text-slate-400">Total Projects</div>
+          </div>
+          <div className="p-4 rounded-xl bg-slate-700/30">
+            <div className="text-2xl font-bold text-white mb-1">
+              {projects.filter((p) => p.status === "in_review" || p.status === "draft").length}
+            </div>
+            <div className="text-sm text-slate-400">Active Projects</div>
+          </div>
+          <div className="p-4 rounded-xl bg-slate-700/30">
+            <div className="text-2xl font-bold text-white mb-1">
+              {projects.filter((p) => p.status === "approved").length}
+            </div>
+            <div className="text-sm text-slate-400">Completed Projects</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ReportsPageWrapper({
+  tasks,
+  projects,
+}: {
+  tasks: TaskWithProject[];
+  projects: ProjectSummary[];
+}) {
+  return <ReportsContent tasks={tasks} projects={projects} />;
+}

--- a/apps/web/src/app/today/page.tsx
+++ b/apps/web/src/app/today/page.tsx
@@ -1,0 +1,8 @@
+import { getAllTasksWithProject } from "@/lib/markdown";
+import TodayPageWrapper from "./today-content";
+
+export default async function TodayPage() {
+  const tasks = await getAllTasksWithProject();
+
+  return <TodayPageWrapper tasks={tasks} />;
+}

--- a/apps/web/src/app/today/today-content.tsx
+++ b/apps/web/src/app/today/today-content.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { TaskWithProject } from "@/lib/markdown";
+import { TaskDetailModal } from "@/components/task-detail-modal";
+import { useTaskIdParam } from "@/lib/search-params";
+import Link from "next/link";
+
+interface TodayPageProps {
+  tasks: TaskWithProject[];
+}
+
+function TodayContent({ tasks }: TodayPageProps) {
+  const [selectedTaskId, setSelectedTaskId] = useTaskIdParam();
+  const today = new Date().toISOString().split("T")[0];
+
+  // Filter tasks due today
+  const todayTasks = tasks.filter((task) => task.dueDate === today);
+
+  // Group by project
+  const tasksByProject = todayTasks.reduce(
+    (acc, task) => {
+      const key = `${task.workspace}/${task.projectSlug}`;
+      if (!acc[key]) {
+        acc[key] = { title: task.projectTitle, tasks: [] };
+      }
+      acc[key].tasks.push(task);
+      return acc;
+    },
+    {} as Record<string, { title: string; tasks: TaskWithProject[] }>
+  );
+
+  const selectedTask = tasks.find((t) => t.id === selectedTaskId);
+
+  const priorityColors = {
+    low: "bg-slate-500/20 text-slate-300 border-slate-500/30",
+    medium: "bg-blue-500/20 text-blue-300 border-blue-500/30",
+    high: "bg-orange-500/20 text-orange-300 border-orange-500/30",
+    critical: "bg-red-500/20 text-red-300 border-red-500/30",
+  };
+
+  const statusColors = {
+    todo: "bg-slate-500",
+    in_progress: "bg-yellow-500",
+    done: "bg-green-500",
+    blocked: "bg-red-500",
+  };
+
+  return (
+    <div className="p-8">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-2">
+          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-amber-500 to-orange-500 flex items-center justify-center">
+            <svg
+              className="w-5 h-5 text-white"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+              />
+            </svg>
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold text-white">Today</h1>
+            <p className="text-slate-400">
+              {new Date().toLocaleDateString("en-US", {
+                weekday: "long",
+                month: "long",
+                day: "numeric",
+              })}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+        <div className="p-4 rounded-xl bg-gradient-to-br from-amber-600/20 to-orange-600/20 border border-amber-500/20">
+          <div className="text-2xl font-bold text-white mb-1">
+            {todayTasks.length}
+          </div>
+          <div className="text-sm text-amber-300">Due Today</div>
+        </div>
+        <div className="p-4 rounded-xl bg-gradient-to-br from-green-600/20 to-emerald-600/20 border border-green-500/20">
+          <div className="text-2xl font-bold text-white mb-1">
+            {todayTasks.filter((t) => t.status === "done").length}
+          </div>
+          <div className="text-sm text-green-300">Completed</div>
+        </div>
+        <div className="p-4 rounded-xl bg-gradient-to-br from-yellow-600/20 to-orange-600/20 border border-yellow-500/20">
+          <div className="text-2xl font-bold text-white mb-1">
+            {todayTasks.filter((t) => t.status === "in_progress").length}
+          </div>
+          <div className="text-sm text-yellow-300">In Progress</div>
+        </div>
+      </div>
+
+      {/* Tasks List */}
+      {todayTasks.length > 0 ? (
+        <div className="space-y-6">
+          {Object.entries(tasksByProject).map(([key, { title, tasks }]) => (
+            <div key={key} className="space-y-3">
+              <h2 className="text-sm font-semibold text-slate-400 uppercase tracking-wider">
+                {title}
+              </h2>
+              <div className="space-y-2">
+                {tasks.map((task) => (
+                  <button
+                    key={task.id}
+                    onClick={() => setSelectedTaskId(task.id)}
+                    className="w-full text-left p-4 rounded-xl bg-slate-800/50 border border-slate-700/50 hover:border-slate-600 transition-all group"
+                  >
+                    <div className="flex items-center justify-between gap-4">
+                      <div className="flex items-center gap-3 min-w-0">
+                        <div
+                          className={`w-2 h-2 rounded-full shrink-0 ${statusColors[task.status]}`}
+                        />
+                        <span className="text-white font-medium truncate group-hover:text-violet-300 transition-colors">
+                          {task.title}
+                        </span>
+                      </div>
+                      <span
+                        className={`px-2 py-0.5 text-xs rounded-full border shrink-0 ${priorityColors[task.priority]}`}
+                      >
+                        {task.priority}
+                      </span>
+                    </div>
+                    {task.description && (
+                      <p className="mt-2 text-sm text-slate-400 line-clamp-1 pl-5">
+                        {task.description}
+                      </p>
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-16 px-8 rounded-2xl bg-slate-800/30 border border-slate-700/50">
+          <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-gradient-to-br from-amber-500/20 to-orange-500/20 flex items-center justify-center">
+            <svg
+              className="w-8 h-8 text-amber-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          </div>
+          <h3 className="text-lg font-semibold text-white mb-2">
+            All clear for today!
+          </h3>
+          <p className="text-slate-400 max-w-md mx-auto">
+            No tasks are due today. Check the{" "}
+            <Link href="/upcoming" className="text-violet-400 hover:underline">
+              Upcoming
+            </Link>{" "}
+            view to see what's coming next.
+          </p>
+        </div>
+      )}
+
+      {/* Task Detail Modal */}
+      {selectedTask && (
+        <TaskDetailModal
+          task={selectedTask}
+          workspace={selectedTask.workspace}
+          projectSlug={selectedTask.projectSlug}
+          onClose={() => setSelectedTaskId(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+export default function TodayPageWrapper({
+  tasks,
+}: {
+  tasks: TaskWithProject[];
+}) {
+  return <TodayContent tasks={tasks} />;
+}

--- a/apps/web/src/app/upcoming/page.tsx
+++ b/apps/web/src/app/upcoming/page.tsx
@@ -1,0 +1,8 @@
+import { getAllTasksWithProject } from "@/lib/markdown";
+import UpcomingPageWrapper from "./upcoming-content";
+
+export default async function UpcomingPage() {
+  const tasks = await getAllTasksWithProject();
+
+  return <UpcomingPageWrapper tasks={tasks} />;
+}

--- a/apps/web/src/app/upcoming/upcoming-content.tsx
+++ b/apps/web/src/app/upcoming/upcoming-content.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { TaskWithProject } from "@/lib/markdown";
+import { TaskDetailModal } from "@/components/task-detail-modal";
+import { useTaskIdParam } from "@/lib/search-params";
+import Link from "next/link";
+
+interface UpcomingPageProps {
+  tasks: TaskWithProject[];
+}
+
+function UpcomingContent({ tasks }: UpcomingPageProps) {
+  const [selectedTaskId, setSelectedTaskId] = useTaskIdParam();
+  
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  
+  const nextWeek = new Date(today);
+  nextWeek.setDate(nextWeek.getDate() + 7);
+
+  // Filter and categorize tasks
+  const upcomingTasks = tasks.filter((task) => {
+    if (!task.dueDate) return false;
+    const dueDate = new Date(task.dueDate);
+    dueDate.setHours(0, 0, 0, 0);
+    return dueDate >= today && dueDate <= nextWeek;
+  });
+
+  const todayTasks = upcomingTasks.filter((task) => {
+    const dueDate = new Date(task.dueDate!);
+    dueDate.setHours(0, 0, 0, 0);
+    return dueDate.getTime() === today.getTime();
+  });
+
+  const tomorrowTasks = upcomingTasks.filter((task) => {
+    const dueDate = new Date(task.dueDate!);
+    dueDate.setHours(0, 0, 0, 0);
+    return dueDate.getTime() === tomorrow.getTime();
+  });
+
+  const laterTasks = upcomingTasks.filter((task) => {
+    const dueDate = new Date(task.dueDate!);
+    dueDate.setHours(0, 0, 0, 0);
+    return dueDate > tomorrow;
+  });
+
+  const selectedTask = tasks.find((t) => t.id === selectedTaskId);
+
+  const priorityColors = {
+    low: "bg-slate-500/20 text-slate-300 border-slate-500/30",
+    medium: "bg-blue-500/20 text-blue-300 border-blue-500/30",
+    high: "bg-orange-500/20 text-orange-300 border-orange-500/30",
+    critical: "bg-red-500/20 text-red-300 border-red-500/30",
+  };
+
+  const statusColors = {
+    todo: "bg-slate-500",
+    in_progress: "bg-yellow-500",
+    done: "bg-green-500",
+    blocked: "bg-red-500",
+  };
+
+  const TaskSection = ({
+    title,
+    tasks,
+    emptyMessage,
+    accentColor = "violet",
+  }: {
+    title: string;
+    tasks: TaskWithProject[];
+    emptyMessage: string;
+    accentColor?: string;
+  }) => (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <h2 className="text-lg font-semibold text-white">{title}</h2>
+        <span className="px-2 py-0.5 text-xs bg-slate-700 rounded-full text-slate-300">
+          {tasks.length}
+        </span>
+      </div>
+      {tasks.length > 0 ? (
+        <div className="space-y-2">
+          {tasks.map((task) => (
+            <button
+              key={task.id}
+              onClick={() => setSelectedTaskId(task.id)}
+              className="w-full text-left p-4 rounded-xl bg-slate-800/50 border border-slate-700/50 hover:border-slate-600 transition-all group"
+            >
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3 min-w-0">
+                  <div
+                    className={`w-2 h-2 rounded-full shrink-0 ${statusColors[task.status]}`}
+                  />
+                  <span className="text-white font-medium truncate group-hover:text-violet-300 transition-colors">
+                    {task.title}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <span className="text-xs text-slate-500">{task.projectTitle}</span>
+                  <span
+                    className={`px-2 py-0.5 text-xs rounded-full border ${priorityColors[task.priority]}`}
+                  >
+                    {task.priority}
+                  </span>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="p-4 rounded-xl bg-slate-800/30 border border-slate-700/30 text-center">
+          <p className="text-sm text-slate-500">{emptyMessage}</p>
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="p-8">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-2">
+          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-cyan-500 to-blue-500 flex items-center justify-center">
+            <svg
+              className="w-5 h-5 text-white"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold text-white">Upcoming</h1>
+            <p className="text-slate-400">Tasks scheduled for the next 7 days</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
+        <div className="p-4 rounded-xl bg-gradient-to-br from-cyan-600/20 to-blue-600/20 border border-cyan-500/20">
+          <div className="text-2xl font-bold text-white mb-1">
+            {upcomingTasks.length}
+          </div>
+          <div className="text-sm text-cyan-300">Total Upcoming</div>
+        </div>
+        <div className="p-4 rounded-xl bg-gradient-to-br from-amber-600/20 to-orange-600/20 border border-amber-500/20">
+          <div className="text-2xl font-bold text-white mb-1">
+            {todayTasks.length}
+          </div>
+          <div className="text-sm text-amber-300">Due Today</div>
+        </div>
+        <div className="p-4 rounded-xl bg-gradient-to-br from-violet-600/20 to-purple-600/20 border border-violet-500/20">
+          <div className="text-2xl font-bold text-white mb-1">
+            {tomorrowTasks.length}
+          </div>
+          <div className="text-sm text-violet-300">Due Tomorrow</div>
+        </div>
+        <div className="p-4 rounded-xl bg-gradient-to-br from-slate-600/20 to-slate-700/20 border border-slate-500/20">
+          <div className="text-2xl font-bold text-white mb-1">
+            {laterTasks.length}
+          </div>
+          <div className="text-sm text-slate-300">This Week</div>
+        </div>
+      </div>
+
+      {/* Task Sections */}
+      {upcomingTasks.length > 0 ? (
+        <div className="space-y-8">
+          {todayTasks.length > 0 && (
+            <TaskSection
+              title="Today"
+              tasks={todayTasks}
+              emptyMessage="No tasks due today"
+            />
+          )}
+          {tomorrowTasks.length > 0 && (
+            <TaskSection
+              title="Tomorrow"
+              tasks={tomorrowTasks}
+              emptyMessage="No tasks due tomorrow"
+            />
+          )}
+          {laterTasks.length > 0 && (
+            <TaskSection
+              title="This Week"
+              tasks={laterTasks}
+              emptyMessage="No tasks this week"
+            />
+          )}
+        </div>
+      ) : (
+        <div className="text-center py-16 px-8 rounded-2xl bg-slate-800/30 border border-slate-700/50">
+          <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-gradient-to-br from-cyan-500/20 to-blue-500/20 flex items-center justify-center">
+            <svg
+              className="w-8 h-8 text-cyan-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+          </div>
+          <h3 className="text-lg font-semibold text-white mb-2">
+            No upcoming tasks
+          </h3>
+          <p className="text-slate-400 max-w-md mx-auto">
+            Tasks with due dates in the next 7 days will appear here. Add{" "}
+            <code className="px-1.5 py-0.5 bg-slate-700 rounded text-violet-300">
+              - **due_date:** YYYY-MM-DD
+            </code>{" "}
+            to your task definitions.
+          </p>
+        </div>
+      )}
+
+      {/* Task Detail Modal */}
+      {selectedTask && (
+        <TaskDetailModal
+          task={selectedTask}
+          workspace={selectedTask.workspace}
+          projectSlug={selectedTask.projectSlug}
+          onClose={() => setSelectedTaskId(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+export default function UpcomingPageWrapper({
+  tasks,
+}: {
+  tasks: TaskWithProject[];
+}) {
+  return <UpcomingContent tasks={tasks} />;
+}

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -108,7 +108,50 @@ export function Sidebar({ projects }: SidebarProps) {
         </div>
       </div>
 
-      {/* Projects List */}
+      {/* Views Navigation */}
+      <div className="px-4 py-3 border-b border-slate-800/50">
+        <h3 className="text-[10px] font-semibold text-slate-500 uppercase tracking-wider mb-2">Views</h3>
+        <nav className="space-y-1">
+          {[
+            { href: "/today", label: "Today", icon: "M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z", color: "from-amber-500 to-orange-500" },
+            { href: "/upcoming", label: "Upcoming", icon: "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z", color: "from-cyan-500 to-blue-500" },
+            { href: "/calendar", label: "Calendar", icon: "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z", color: "from-purple-500 to-pink-500" },
+            { href: "/reports", label: "Reports", icon: "M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z", color: "from-emerald-500 to-teal-500" },
+          ].map((view) => {
+            const isActive = pathname === view.href;
+            return (
+              <Link
+                key={view.href}
+                href={view.href}
+                className={cn(
+                  "flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200 group",
+                  isActive
+                    ? "bg-slate-800 text-white"
+                    : "text-slate-400 hover:bg-slate-800/50 hover:text-slate-200"
+                )}
+              >
+                <div className={cn(
+                  "w-6 h-6 rounded-md flex items-center justify-center bg-gradient-to-br",
+                  isActive ? view.color : "from-slate-700 to-slate-600"
+                )}>
+                  <svg
+                    className="w-3.5 h-3.5 text-white"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={view.icon} />
+                  </svg>
+                </div>
+                <span className="text-sm font-medium">{view.label}</span>
+                {isActive && (
+                  <div className="ml-auto w-1.5 h-1.5 rounded-full bg-violet-500" />
+                )}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
       <div className="flex-1 overflow-y-auto p-4 space-y-4 scrollbar-thin scrollbar-thumb-slate-800 scrollbar-track-transparent">
         {Object.entries(projectsByWorkspace).map(([workspace, workspaceProjects]) => {
           const isCollapsed = collapsedWorkspaces[workspace];

--- a/apps/web/src/lib/search-params.ts
+++ b/apps/web/src/lib/search-params.ts
@@ -2,6 +2,9 @@ import { useQueryState, parseAsString, parseAsStringEnum } from 'nuqs'
 
 export const taskStatusParser = parseAsStringEnum(['all', 'todo', 'in_progress', 'done', 'blocked'])
 
+/**
+ * Hook for managing task-related URL search params (taskId and filter)
+ */
 export function useTaskSearchParams() {
   const [taskId, setTaskId] = useQueryState('task', parseAsString)
   const [filter, setFilter] = useQueryState('filter', taskStatusParser.withDefault('all'))
@@ -11,5 +14,40 @@ export function useTaskSearchParams() {
     setTaskId,
     filter,
     setFilter
+  }
+}
+
+/**
+ * Simple hook for managing just the taskId URL param.
+ * Returns a tuple [taskId, setTaskId] for consistency with useState pattern.
+ */
+export function useTaskIdParam() {
+  const [taskId, setTaskId] = useQueryState('task', parseAsString)
+  return [taskId, setTaskId] as const
+}
+
+/**
+ * Generic hook for managing tab selection via URL search params.
+ * Supports shareable and bookmarkable URLs with tab state.
+ * 
+ * @param validTabs - Array of valid tab values
+ * @param defaultTab - Default tab to use when no tab is specified in URL
+ * @param paramName - URL param name (defaults to 'tab')
+ * 
+ * @example
+ * // In a component with tabs
+ * const { tab, setTab } = useTabParam(['overview', 'details', 'history'], 'overview')
+ */
+export function useTabParam<T extends string>(
+  validTabs: readonly T[],
+  defaultTab: T,
+  paramName: string = 'tab'
+) {
+  const tabParser = parseAsStringEnum(validTabs as unknown as string[])
+  const [tab, setTab] = useQueryState(paramName, tabParser.withDefault(defaultTab as string))
+
+  return {
+    tab: tab as T,
+    setTab: setTab as (value: T | null) => Promise<URLSearchParams>
   }
 }

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -51,6 +51,7 @@ export const taskSchema = z.object({
   status: taskStatusSchema,
   priority: taskPrioritySchema,
   description: z.string(),
+  dueDate: z.string().optional(),
   subtasks: z.array(subtaskSchema).default([]),
   comments: z.array(z.string()).default([]),
 });

--- a/projects/blueprint-ai/navigation-redesign/tasks.md
+++ b/projects/blueprint-ai/navigation-redesign/tasks.md
@@ -28,22 +28,22 @@ Implemented workflow grouping mode with toggle UI in sidebar.
 
 ## Task 2: New Dashboard Views
 - **id:** nav-102
-- **status:** todo
+- **status:** done
 - **priority:** medium
 - **description:** Implement new high-level views for task aggregation.
 
 ### Subtasks
 
-#### [ ] "Today" View
+#### [x] "Today" View
 Aggregate tasks due today or marked for today across all/filtered projects.
 
-#### [ ] "Upcoming" View
+#### [x] "Upcoming" View
 List tasks scheduled for the near future.
 
-#### [ ] "Calendar" View
+#### [x] "Calendar" View
 Visual calendar representation of project milestones and task due dates.
 
-#### [ ] "Reports" View
+#### [x] "Reports" View
 High-level stats and reporting dashboard (as seen in the design concept).
 
 ---


### PR DESCRIPTION
## Summary

Implements Task 2 from the **navigation-redesign** project: New Dashboard Views for task aggregation.

## Changes

### New Pages
| View | Route | Description |
|------|-------|-------------|
| Today | `/today` | Tasks due today |
| Upcoming | `/upcoming` | Tasks due in the next 7 days |
| Calendar | `/calendar` | Monthly grid with task indicators |
| Reports | `/reports` | Analytics dashboard with charts |

### Schema Enhancement
- Added optional `dueDate` field to Task schema
- Tasks can now include `- **due_date:** YYYY-MM-DD` in markdown

### Data Layer
- Added `getAllTasksWithProject()` function for cross-project queries
- Added `useTaskIdParam` hook for URL-based task selection

### UI
- Added "Views" navigation section in sidebar with 4 links
- Each page has stats cards, content area, and empty states

## Testing
- Verified all 4 pages load correctly
- Verified sidebar navigation works with active states
- Verified empty states display appropriately

## Related
- Task ID: nav-102
- Project: navigation-redesign