### PR TITLE
chore(branding): rename BlueprintAI to Transmute

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # AGENTS.md
 
-Instructions for AI coding agents working on BlueprintAI.
+Instructions for AI coding agents working on Transmute.
 
 ## Project Overview
 
-BlueprintAI is a task management system where AI agents generate PRDs (Product Requirements Documents) and based on PRDs, generate tasks in markdown format, that are rendered in a Next.js web app with a premium UI.
+Transmute is a task management system where AI agents generate PRDs (Product Requirements Documents) and based on PRDs, generate tasks in markdown format, that are rendered in a Next.js web app with a premium UI.
 
 ## Setup Commands
 
@@ -33,7 +33,7 @@ pnpm lint
 ## Project Structure
 
 ```
-blueprint-ai/
+transmute/
 ├── projects/                  # Markdown content (PRDs + Tasks)
 ├── src/
 │   ├── app/                   # Next.js App Router pages
@@ -52,7 +52,7 @@ Create files in `projects/<project-slug>/`:
 ---
 id: "project-slug"
 title: "Project Title"
-status: "draft"           # draft | in_review | approved | rejected
+status: "draft" # draft | in_review | approved | rejected
 version: "1.0"
 created_at: "YYYY-MM-DD"
 updated_at: "YYYY-MM-DD"
@@ -62,9 +62,11 @@ author: "ai-agent"
 # Project Title
 
 ## Objetivo
+
 Description of the goal...
 
 ## Requisitos Funcionais
+
 1. Requirement 1
 2. Requirement 2
 ```
@@ -82,17 +84,20 @@ updated_at: "YYYY-MM-DD"
 # Tasks: Project Title
 
 ## Task 1: Task Title
+
 - **id:** task-001
-- **status:** todo          # todo | in_progress | done | blocked
-- **priority:** high        # low | medium | high | critical
+- **status:** todo # todo | in_progress | done | blocked
+- **priority:** high # low | medium | high | critical
 - **description:** Clear description of the task.
 
 ### Subtasks
 
 #### [ ] Subtask Title
+
 Description of the subtask.
 
 #### [x] Completed Subtask
+
 This subtask is done.
 ```
 
@@ -102,13 +107,13 @@ This subtask is done.
 2. User reviews and approves (status → `approved`)
 3. Generate `tasks.md` based on approved PRD
 4. Update `updated_at` when modifying files with current date
-5. **System Documentation**: When modifying the **BlueprintAI codebase** (e.g., adding features, updating APIs, changing schemas), you MUST check and update `apps/docs` to reflect these changes. This ensures the system documentation remains accurate.
-6. **Task Execution & Isolation**: 
-   - Treat each Task as a specific **deliverable** (analogous to a git branch). 
-   - **Work on ONLY ONE task per session**. 
+5. **System Documentation**: When modifying the **Transmute codebase** (e.g., adding features, updating APIs, changing schemas), you MUST check and update `apps/docs` to reflect these changes. This ensures the system documentation remains accurate.
+6. **Task Execution & Isolation**:
+   - Treat each Task as a specific **deliverable** (analogous to a git branch).
+   - **Work on ONLY ONE task per session**.
    - **STOP** after completing and verifying your SINGLE assigned task. Do NOT automatically proceed to the next task in the list. This avoids race conditions where multiple agents might accidentally duplicate work on the same future tasks.
 
-7. **Ambiguity Resolution - "Create Tasks"**: 
+7. **Ambiguity Resolution - "Create Tasks"**:
    - If a user asks to "create tasks", "register tasks", or "add pending items", they almost always mean creating or updating a `tasks.md` file within the `projects/` structure (the System).
    - Do NOT create a local/temporary todo list unless explicitly asked for a personal plan.
    - If the specific workspace or project mentioned does not exist in `projects/`, you should CREATE the necessary directory structure and files (`prd.md` and `tasks.md`).
@@ -179,98 +184,117 @@ This subtask is done.
       - The Pull Request URL (if applicable)
     - This allows the user to immediately verify the changes in the browser.
 
-
-
 ## State Management Guidelines
 
 To ensure consistency and correct behavior across the application, follow these boundaries for state management:
 
 ### 1. URL State (nuqs)
+
 **Use for:** Shareable, bookmarkable, or deep-linkable state.
+
 - **Filters/Sorts:** List filters (e.g., `?status=done`), sorting preferences.
 - **Selection:** Currently selected item (e.g., `?task=task-123`).
 - **Pagination:** Current page number (e.g., `?page=2`).
 - **View Modes:** Tabs or view toggles that affect the main content (e.g., `?view=calendar`).
 
 **Pattern:** Create a custom hook in `@/lib/search-params.ts` to wrap `useQueryState`.
+
 ```typescript
 // @/lib/search-params.ts
 export function useTaskSearchParams() {
-  const [filter, setFilter] = useQueryState('filter', parseAsString.withDefault('all'))
-  return { filter, setFilter }
+  const [filter, setFilter] = useQueryState(
+    "filter",
+    parseAsString.withDefault("all"),
+  );
+  return { filter, setFilter };
 }
 ```
 
 ### 2. Application State (Zustand)
+
 **Use for:** Global app state, server cache, or user preferences that shouldn't be in the URL.
+
 - **Server Cache:** Optimistic updates, data cache (e.g., `optimisticStatus`).
 - **UI State (Ephemeral):** Loading states, pending flags, drag-and-drop intermediate state.
 - **UI Preferences (Persisted):** Sidebar collapse state, theme preference, "Show archived" sidebar toggle (if tailored to user).
 
 **Pattern:** Create feature-specific stores in `@/lib/stores/`.
+
 ```typescript
 // @/lib/stores/ui-store.ts
 export const useUIStore = create<UIStore>()(
   persist(
     (set) => ({
       sidebarOpen: true,
-      toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
+      toggleSidebar: () =>
+        set((state) => ({ sidebarOpen: !state.sidebarOpen })),
     }),
-    { name: 'ui-store' }
-  )
-)
+    { name: "ui-store" },
+  ),
+);
 ```
 
 ### 3. Integration Logic
+
 - **Do NOT duplicate URL state in Zustand** unless absolutely necessary (e.g., complex derived state that needs to be accessed outside React tree - rare).
 - **Read-Write separation:** Components should read from URL hooks for rendering and write to URL hooks for user actions.
-- **Syncing:** If an optimistic update needs to reflect immediately while the server processes, store the *pending* state in Zustand, but the *source of truth* for the initial view remains the server data + URL params. (See `useTaskStore.optimisticStatus`).
-
+- **Syncing:** If an optimistic update needs to reflect immediately while the server processes, store the _pending_ state in Zustand, but the _source of truth_ for the initial view remains the server data + URL params. (See `useTaskStore.optimisticStatus`).
 
 ## State Management Guidelines
 
 To ensure consistency and correct behavior across the application, follow these boundaries for state management:
 
 ### 1. URL State (nuqs)
+
 **Use for:** Shareable, bookmarkable, or deep-linkable state.
+
 - **Filters/Sorts:** List filters (e.g., `?status=done`), sorting preferences.
 - **Selection:** Currently selected item (e.g., `?task=task-123`).
 - **Pagination:** Current page number (e.g., `?page=2`).
 - **View Modes:** Tabs or view toggles that affect the main content (e.g., `?view=calendar`).
 
 **Pattern:** Create a custom hook in `@/lib/search-params.ts` to wrap `useQueryState`.
+
 ```typescript
 // @/lib/search-params.ts
 export function useTaskSearchParams() {
-  const [filter, setFilter] = useQueryState('filter', parseAsString.withDefault('all'))
-  return { filter, setFilter }
+  const [filter, setFilter] = useQueryState(
+    "filter",
+    parseAsString.withDefault("all"),
+  );
+  return { filter, setFilter };
 }
 ```
 
 ### 2. Application State (Zustand)
+
 **Use for:** Global app state, server cache, or user preferences that shouldn't be in the URL.
+
 - **Server Cache:** Optimistic updates, data cache (e.g., `optimisticStatus`).
 - **UI State (Ephemeral):** Loading states, pending flags, drag-and-drop intermediate state.
 - **UI Preferences (Persisted):** Sidebar collapse state, theme preference, "Show archived" sidebar toggle (if tailored to user).
 
 **Pattern:** Create feature-specific stores in `@/lib/stores/`.
+
 ```typescript
 // @/lib/stores/ui-store.ts
 export const useUIStore = create<UIStore>()(
   persist(
     (set) => ({
       sidebarOpen: true,
-      toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
+      toggleSidebar: () =>
+        set((state) => ({ sidebarOpen: !state.sidebarOpen })),
     }),
-    { name: 'ui-store' }
-  )
-)
+    { name: "ui-store" },
+  ),
+);
 ```
 
 ### 3. Integration Logic
+
 - **Do NOT duplicate URL state in Zustand** unless absolutely necessary (e.g., complex derived state that needs to be accessed outside React tree - rare).
 - **Read-Write separation:** Components should read from URL hooks for rendering and write to URL hooks for user actions.
-- **Syncing:** If an optimistic update needs to reflect immediately while the server processes, store the *pending* state in Zustand, but the *source of truth* for the initial view remains the server data + URL params. (See `useTaskStore.optimisticStatus`).
+- **Syncing:** If an optimistic update needs to reflect immediately while the server processes, store the _pending_ state in Zustand, but the _source of truth_ for the initial view remains the server data + URL params. (See `useTaskStore.optimisticStatus`).
 
 ## Git Conventions
 
@@ -312,5 +336,3 @@ After completing a task and creating the PR, the agent MUST perform a **learning
    - `.agent/workflows/` — for repeatable multi-step processes
 
 > **Goal**: Each session should leave behind wisdom for future agents. The guidelines file is a living document that evolves with practical experience.
-
-

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="docs/assets/logo.svg" alt="BlueprintAI Logo" width="80" height="80">
+  <img src="docs/assets/logo.svg" alt="Transmute Logo" width="80" height="80">
 </p>
 
-<h1 align="center">BlueprintAI</h1>
+<h1 align="center">Transmute</h1>
 
 <p align="center">
   <strong>AI-powered PRD & task management system</strong>
@@ -56,8 +56,8 @@
 
 ```bash
 # Clone the repository
-git clone https://github.com/1001Josias/blueprint-ai.git
-cd blueprint-ai
+git clone https://github.com/1001Josias/transmute.git
+cd transmute
 
 # Install dependencies
 pnpm install
@@ -71,11 +71,13 @@ Open [http://localhost:3000](http://localhost:3000) to see the app.
 ### Creating Your First Project
 
 1. Create a new directory in `projects/`:
+
    ```bash
    mkdir -p projects/my-project
    ```
 
 2. Create `prd.md` with your PRD:
+
    ```markdown
    ---
    id: "my-project"
@@ -90,10 +92,12 @@ Open [http://localhost:3000](http://localhost:3000) to see the app.
    # My Awesome Project
 
    ## Objetivo
+
    Description of what this project aims to achieve...
    ```
 
 3. Create `tasks.md` with your tasks:
+
    ```markdown
    ---
    project_id: "my-project"
@@ -105,6 +109,7 @@ Open [http://localhost:3000](http://localhost:3000) to see the app.
    # Tasks: My Awesome Project
 
    ## Task 1: First Task
+
    - **id:** task-001
    - **status:** todo
    - **priority:** high
@@ -113,6 +118,7 @@ Open [http://localhost:3000](http://localhost:3000) to see the app.
    ### Subtasks
 
    #### [ ] First subtask
+
    Description of what needs to be done.
    ```
 
@@ -120,7 +126,7 @@ Open [http://localhost:3000](http://localhost:3000) to see the app.
 
 ## 🤖 For AI Agents
 
-BlueprintAI is designed to work seamlessly with AI coding assistants. See [AGENTS.md](AGENTS.md) for:
+Transmute is designed to work seamlessly with AI coding assistants. See [AGENTS.md](AGENTS.md) for:
 
 - Setup commands and code style
 - PRD and Tasks markdown schemas
@@ -128,15 +134,15 @@ BlueprintAI is designed to work seamlessly with AI coding assistants. See [AGENT
 
 ### Quick Reference
 
-| Field | PRD Values | Task Values |
-|-------|------------|-------------|
-| **Status** | `draft`, `in_review`, `approved`, `rejected` | `todo`, `in_progress`, `done`, `blocked` |
-| **Priority** | - | `low`, `medium`, `high`, `critical` |
+| Field        | PRD Values                                   | Task Values                              |
+| ------------ | -------------------------------------------- | ---------------------------------------- |
+| **Status**   | `draft`, `in_review`, `approved`, `rejected` | `todo`, `in_progress`, `done`, `blocked` |
+| **Priority** | -                                            | `low`, `medium`, `high`, `critical`      |
 
 ## 📁 Project Structure
 
 ```
-blueprint-ai/
+transmute/
 ├── apps/
 │   ├── web/                   # Next.js App Router (Main App)
 │   └── docs/                  # Fumadocs Documentation Site
@@ -153,23 +159,24 @@ blueprint-ai/
 
 ## 🛠️ Tech Stack
 
-| Category | Technology |
-|----------|------------|
-| **Framework** | [Next.js 15](https://nextjs.org/) (App Router) |
-| **Language** | [TypeScript](https://www.typescriptlang.org/) |
-| **Styling** | [Tailwind CSS](https://tailwindcss.com/) |
-| **Markdown** | [gray-matter](https://github.com/jonschlinkert/gray-matter) + [remark](https://github.com/remarkjs/remark) |
-| **Validation** | [Zod](https://zod.dev/) |
-| **Package Manager** | [pnpm](https://pnpm.io/) |
+| Category            | Technology                                                                                                 |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Framework**       | [Next.js 15](https://nextjs.org/) (App Router)                                                             |
+| **Language**        | [TypeScript](https://www.typescriptlang.org/)                                                              |
+| **Styling**         | [Tailwind CSS](https://tailwindcss.com/)                                                                   |
+| **Markdown**        | [gray-matter](https://github.com/jonschlinkert/gray-matter) + [remark](https://github.com/remarkjs/remark) |
+| **Validation**      | [Zod](https://zod.dev/)                                                                                    |
+| **Package Manager** | [pnpm](https://pnpm.io/)                                                                                   |
 
 ## 🗺️ Roadmap
 
 ## 🗺️ Roadmap & Projects
 
-BlueprintAI is built by BlueprintAI. We use our own system to manage our roadmap.
+Transmute is built by Transmute. We use our own system to manage our roadmap.
 Check out the defined projects below:
 
 ### Core Definitions (New!)
+
 - [**Workspaces & Access Control**](content/projects/workspaces/prd.md) - The "House" concept for isolation.
 - [**Task Dependencies**](content/projects/task-dependencies/prd.md) - Blockers and prerequisites.
 - [**External Agent API**](content/projects/agent-communication/prd.md) - allowing agents to work together.
@@ -177,6 +184,7 @@ Check out the defined projects below:
 - [**Task Drag & Drop**](content/projects/task-drag-and-drop/prd.md) - Reordering tasks visually.
 
 ### Upcoming Features
+
 - [**UI Editing & Interactivity (v1.1)**](content/projects/ui-editing/prd.md) - Edit tasks without Markdown.
 - [**Integrations (v1.2)**](content/projects/integrations/prd.md) - GitHub, Jira, Linear sync.
 - [**Enterprise Core (v2.0)**](content/projects/enterprise-core/prd.md) - Multi-user, DB, Real-time.
@@ -187,4 +195,3 @@ Check out the defined projects below:
 <p align="center">
   Made with 💜 by Josias Junior
 </p>
-

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -1,23 +1,23 @@
-import Link from 'next/link';
+import Link from "next/link";
 
 export default function HomePage() {
   return (
     <main className="flex flex-1 flex-col justify-center text-center">
-      <h1 className="mb-4 text-4xl font-bold">BlueprintAI</h1>
+      <h1 className="mb-4 text-4xl font-bold">Transmute</h1>
       <p className="mb-8 text-lg text-muted-foreground">
         Intelligent Task Management System designed for Agents and Humans.
       </p>
-      
+
       <div className="flex justify-center gap-4 mb-16">
-        <Link 
-          href="/docs" 
+        <Link
+          href="/docs"
           className="rounded-full bg-foreground text-background px-6 py-3 font-medium transition-colors hover:bg-muted-foreground"
         >
           Get Started
         </Link>
-        <a 
-          href="https://github.com/1001Josias/blueprint-ai" 
-          target="_blank" 
+        <a
+          href="https://github.com/1001Josias/transmute"
+          target="_blank"
           rel="noreferrer"
           className="rounded-full border border-border px-6 py-3 font-medium transition-colors hover:bg-muted"
         >
@@ -29,19 +29,22 @@ export default function HomePage() {
         <div className="p-6 rounded-lg border bg-card text-card-foreground">
           <h3 className="font-semibold text-xl mb-2">Designed for Agents</h3>
           <p className="text-muted-foreground">
-            Generate PRDs and Tasks using standard Markdown. A simple interface ideal for LLMs.
+            Generate PRDs and Tasks using standard Markdown. A simple interface
+            ideal for LLMs.
           </p>
         </div>
         <div className="p-6 rounded-lg border bg-card text-card-foreground">
           <h3 className="font-semibold text-xl mb-2">Built for Humans</h3>
           <p className="text-muted-foreground">
-            Rich, interactive interfaces that parse agent-generated files into a premium UI experience.
+            Rich, interactive interfaces that parse agent-generated files into a
+            premium UI experience.
           </p>
         </div>
         <div className="p-6 rounded-lg border bg-card text-card-foreground">
           <h3 className="font-semibold text-xl mb-2">Bridge to Enterprise</h3>
           <p className="text-muted-foreground">
-            Designed to integrate with enterprise systems like Jira and Linear, closing the loop.
+            Designed to integrate with enterprise systems like Jira and Linear,
+            closing the loop.
           </p>
         </div>
       </div>

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,44 +1,44 @@
-import { RootProvider } from 'fumadocs-ui/provider/next';
-import './global.css';
-import { Inter } from 'next/font/google';
-import type { Metadata } from 'next';
+import { RootProvider } from "fumadocs-ui/provider/next";
+import "./global.css";
+import { Inter } from "next/font/google";
+import type { Metadata } from "next";
 
 const inter = Inter({
-  subsets: ['latin'],
+  subsets: ["latin"],
 });
 
 export const metadata: Metadata = {
   title: {
-    default: 'BlueprintAI Documentation',
-    template: '%s | BlueprintAI',
+    default: "Transmute Documentation",
+    template: "%s | Transmute",
   },
   description:
-    'Intelligent Task Management System designed for AI Agents and Humans. Bridge the gap between AI-generated workflows and enterprise execution.',
+    "Intelligent Task Management System designed for AI Agents and Humans. Bridge the gap between AI-generated workflows and enterprise execution.",
   keywords: [
-    'task management',
-    'ai agents',
-    'automation',
-    'project management',
-    'prd',
-    'blueprintai',
-    'jira integration',
-    'linear integration',
+    "task management",
+    "ai agents",
+    "automation",
+    "project management",
+    "prd",
+    "transmute",
+    "jira integration",
+    "linear integration",
   ],
-  authors: [{ name: 'BlueprintAI Team' }],
-  creator: 'BlueprintAI',
+  authors: [{ name: "Transmute Team" }],
+  creator: "Transmute",
   openGraph: {
-    type: 'website',
-    locale: 'en_US',
-    siteName: 'BlueprintAI Documentation',
-    title: 'BlueprintAI Documentation',
+    type: "website",
+    locale: "en_US",
+    siteName: "Transmute Documentation",
+    title: "Transmute Documentation",
     description:
-      'Intelligent Task Management System designed for AI Agents and Humans.',
+      "Intelligent Task Management System designed for AI Agents and Humans.",
   },
   twitter: {
-    card: 'summary_large_image',
-    title: 'BlueprintAI Documentation',
+    card: "summary_large_image",
+    title: "Transmute Documentation",
     description:
-      'Intelligent Task Management System designed for AI Agents and Humans.',
+      "Intelligent Task Management System designed for AI Agents and Humans.",
   },
   robots: {
     index: true,
@@ -46,7 +46,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default function Layout({ children }: LayoutProps<'/'>) {
+export default function Layout({ children }: LayoutProps<"/">) {
   return (
     <html lang="en" className={inter.className} suppressHydrationWarning>
       <body className="flex flex-col min-h-screen">

--- a/apps/docs/content/docs/core-concepts/projects.mdx
+++ b/apps/docs/content/docs/core-concepts/projects.mdx
@@ -25,5 +25,4 @@ projects/
 
 ## Task Parsing
 
-BlueprintAI automatically parses `tasks.md` files within project directories to generate the task board and list views in the web application.
-
+Transmute automatically parses `tasks.md` files within project directories to generate the task board and list views in the web application.

--- a/apps/docs/content/docs/core-concepts/tasks.mdx
+++ b/apps/docs/content/docs/core-concepts/tasks.mdx
@@ -1,11 +1,11 @@
 ---
 title: Tasks
-description: Understanding Tasks in BlueprintAI
+description: Understanding Tasks in Transmute
 ---
 
 # Tasks
 
-Tasks are the fundamental units of work in BlueprintAI. They represent actionable items that need to be completed.
+Tasks are the fundamental units of work in Transmute. They represent actionable items that need to be completed.
 
 ## Structure
 
@@ -24,4 +24,3 @@ Tasks can have subtasks, allowing for granular breakdown of complex activities. 
 ## Markdown Support
 
 The core of a Task's detailed description is written in Markdown. This allows for rich text formatting, code blocks, and lists to clearly define requirements.
-

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -1,21 +1,19 @@
 ---
 title: Getting Started
-description: Introduction to BlueprintAI Task Management System
+description: Introduction to Transmute Task Management System
 ---
 
-# BlueprintAI
+# Transmute
 
-BlueprintAI is an intelligent Task Management System designed to streamline project workflows and enhance productivity through AI-driven automation.
+Transmute is an intelligent Task Management System designed to streamline project workflows and enhance productivity through AI-driven automation.
 
 ## Core Philosophy
 
-BlueprintAI was architected with a specific vision: **Bridging the gap between AI Agents and Human UX**.
+Transmute was architected with a specific vision: **Bridging the gap between AI Agents and Human UX**.
 
 - **Designed for Agents**: The system enables AI agents to generate Product Requirements (PRDs) and Tasks using standard **Markdown**. This simple, text-based interface is ideal for LLMs to generate structured, consistent content without complex API overhead.
-- **Built for Humans**: While agents speak Markdown, humans prefer rich, interactive interfaces. BlueprintAI parses these agent-generated files to render a **premium, user-friendly UI**, providing a seamless experience for tracking progress, managing priorities, and visualizing project status.
-- **Bridge to Enterprise**: BlueprintAI isn't just a local sandbox. We are designing native integrations to seamlessly transform your local tasks into deliverables within your company's task management systems (like Jira, Linear, or Asana), closing the loop between AI planning and enterprise execution.
+- **Built for Humans**: While agents speak Markdown, humans prefer rich, interactive interfaces. Transmute parses these agent-generated files to render a **premium, user-friendly UI**, providing a seamless experience for tracking progress, managing priorities, and visualizing project status.
+- **Bridge to Enterprise**: Transmute isn't just a local sandbox. We are designing native integrations to seamlessly transform your local tasks into deliverables within your company's task management systems (like Jira, Linear, or Asana), closing the loop between AI planning and enterprise execution.
 
 > [!NOTE]
-> Are you a developer looking to contribute? Check out our [README](https://github.com/1001Josias/blueprint-ai) and [AGENTS.md](https://github.com/1001Josias/blueprint-ai/blob/main/AGENTS.md) for technical architecture and setup instructions.
-
-
+> Are you a developer looking to contribute? Check out our [README](https://github.com/1001Josias/transmute) and [AGENTS.md](https://github.com/1001Josias/transmute/blob/main/AGENTS.md) for technical architecture and setup instructions.

--- a/apps/docs/content/docs/resources/agents.mdx
+++ b/apps/docs/content/docs/resources/agents.mdx
@@ -5,11 +5,11 @@ description: Configuration and Guidelines for AI Agents
 
 # Agents Configuration
 
-This section provides instructions for AI coding agents working on BlueprintAI, based on the `AGENTS.md` specification.
+This section provides instructions for AI coding agents working on Transmute, based on the `AGENTS.md` specification.
 
 ## Project Overview
 
-BlueprintAI is a task management system where AI agents generate PRDs (Product Requirements Documents) and tasks in markdown format.
+Transmute is a task management system where AI agents generate PRDs (Product Requirements Documents) and tasks in markdown format.
 
 ## Workflows
 
@@ -33,6 +33,7 @@ author: "ai-agent"
 # Project Title
 
 ## Objective
+
 ...
 ```
 
@@ -49,6 +50,7 @@ updated_at: "YYYY-MM-DD"
 # Tasks: Project Title
 
 ## Task 1: Task Title
+
 - **id:** task-001
 - **status:** todo
 - **priority:** high
@@ -57,7 +59,7 @@ updated_at: "YYYY-MM-DD"
 
 ### System Documentation Protocol
 
-**Critical:** When modifying the **BlueprintAI codebase** (e.g., adding features, updating APIs, changing schemas), the agent **must** verify if the documentation in `apps/docs` requires updates and perform those updates immediately. This ensures the system documentation remains accurate.
+**Critical:** When modifying the **Transmute codebase** (e.g., adding features, updating APIs, changing schemas), the agent **must** verify if the documentation in `apps/docs` requires updates and perform those updates immediately. This ensures the system documentation remains accurate.
 
 ## Code Style
 
@@ -65,4 +67,3 @@ updated_at: "YYYY-MM-DD"
 - **Styling**: Tailwind CSS (use `cn()` utility).
 - **Validation**: Zod schemas.
 - **Naming**: Kebab-case for files, PascalCase for components.
-

--- a/apps/docs/content/docs/resources/api.mdx
+++ b/apps/docs/content/docs/resources/api.mdx
@@ -1,6 +1,6 @@
 ---
 title: API Reference
-description: API Endpoints for BlueprintAI
+description: API Endpoints for Transmute
 ---
 
 # API Reference
@@ -16,13 +16,13 @@ Updates the status of a specific task or its subtasks.
 
 #### Request Body
 
-| Field | Type | Required | Description |
-| :--- | :--- | :--- | :--- |
-| `projectSlug` | `string` | Yes | The slug of the project containing the task. |
-| `taskId` | `string` | Yes | The ID of the task to update (in URL and body). |
-| `status` | `string` | No | New status (`todo`, `in_progress`, `done`, `blocked`). |
-| `subtaskIndex` | `number` | No | Index of the subtask to update. |
-| `completed` | `boolean` | No | Completion status of the subtask. |
+| Field          | Type      | Required | Description                                            |
+| :------------- | :-------- | :------- | :----------------------------------------------------- |
+| `projectSlug`  | `string`  | Yes      | The slug of the project containing the task.           |
+| `taskId`       | `string`  | Yes      | The ID of the task to update (in URL and body).        |
+| `status`       | `string`  | No       | New status (`todo`, `in_progress`, `done`, `blocked`). |
+| `subtaskIndex` | `number`  | No       | Index of the subtask to update.                        |
+| `completed`    | `boolean` | No       | Completion status of the subtask.                      |
 
 #### Example: Update Main Task
 
@@ -56,4 +56,3 @@ curl -X PATCH http://localhost:3000/api/tasks/task-001 \
   "updatedAt": "2024-01-20"
 }
 ```
-

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -1,6 +1,6 @@
-import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
+import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
 
-import { Logo } from '@repo/ui';
+import { Logo } from "@repo/ui";
 
 export function baseOptions(): BaseLayoutProps {
   return {
@@ -8,7 +8,7 @@ export function baseOptions(): BaseLayoutProps {
       title: (
         <>
           <Logo width={24} height={24} className="text-foreground" />
-          <span className="font-semibold ml-2">BlueprintAI</span>
+          <span className="font-semibold ml-2">Transmute</span>
         </>
       ),
     },

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,13 +3,13 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import { Sidebar } from "@/components/sidebar";
 import { getAllProjects } from "@/lib/markdown";
-import { NuqsAdapter } from 'nuqs/adapters/next/app'
+import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { headers } from "next/headers";
 
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "BlueprintAI",
+  title: "Transmute",
   description: "AI-Powered Task Management",
 };
 
@@ -28,9 +28,7 @@ export default async function RootLayout({
         <NuqsAdapter>
           <div className="flex min-h-screen bg-linear-to-br from-slate-950 via-slate-900 to-slate-950">
             <Sidebar projects={projects} />
-            <main className="flex-1 overflow-y-auto">
-              {children}
-            </main>
+            <main className="flex-1 overflow-y-auto">{children}</main>
           </div>
         </NuqsAdapter>
       </body>

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -20,7 +20,9 @@ const statusColors = {
 
 // Map typical workspaces to icons/colors (or generate based on name)
 const getWorkspaceColor = (workspace: string) => {
-  const hash = workspace.split("").reduce((acc, char) => char.charCodeAt(0) + acc, 0);
+  const hash = workspace
+    .split("")
+    .reduce((acc, char) => char.charCodeAt(0) + acc, 0);
   const colors = [
     "from-violet-500 to-purple-500",
     "from-blue-500 to-cyan-500",
@@ -33,36 +35,46 @@ const getWorkspaceColor = (workspace: string) => {
 
 export function Sidebar({ projects }: SidebarProps) {
   const pathname = usePathname();
-  const { collapsedWorkspaces, sidebarStatusFilter, toggleWorkspace, setSidebarFilter } = useUIStore();
+  const {
+    collapsedWorkspaces,
+    sidebarStatusFilter,
+    toggleWorkspace,
+    setSidebarFilter,
+  } = useUIStore();
 
   // Filter projects by status
   const filteredProjects = projects.filter((project) => {
     if (sidebarStatusFilter === "all") return true;
-    
+
     if (sidebarStatusFilter === "planning") {
       return project.status === "draft" || project.status === "in_review";
     }
 
     if (sidebarStatusFilter === "in_progress") {
       // In Progress = Approved AND not all tasks done
-      // If logic requires Approved to be strictly In Progress only if it has todo/inprogress tasks, 
+      // If logic requires Approved to be strictly In Progress only if it has todo/inprogress tasks,
       // we check taskStats. But "Approved" usually implies it's active project execution.
       // We explicitly exclude "Completed" projects (where done == total and total > 0).
-      const isCompleted = project.taskStats.total > 0 && project.taskStats.done === project.taskStats.total;
+      const isCompleted =
+        project.taskStats.total > 0 &&
+        project.taskStats.done === project.taskStats.total;
       return project.status === "approved" && !isCompleted;
     }
-    
+
     return false;
   });
 
   // Group projects by workspace
-  const projectsByWorkspace = filteredProjects.reduce((acc, project) => {
-    if (!acc[project.workspace]) {
-      acc[project.workspace] = [];
-    }
-    acc[project.workspace].push(project);
-    return acc;
-  }, {} as Record<string, ProjectSummary[]>);
+  const projectsByWorkspace = filteredProjects.reduce(
+    (acc, project) => {
+      if (!acc[project.workspace]) {
+        acc[project.workspace] = [];
+      }
+      acc[project.workspace].push(project);
+      return acc;
+    },
+    {} as Record<string, ProjectSummary[]>,
+  );
 
   return (
     <aside className="w-72 h-screen bg-slate-950 border-r border-slate-800 flex flex-col overflow-hidden">
@@ -70,16 +82,18 @@ export function Sidebar({ projects }: SidebarProps) {
       <div className="p-6 border-b border-slate-800 bg-slate-900/50 backdrop-blur-xl">
         <Link href="/" className="flex items-center gap-3 group">
           <div className="relative w-10 h-10 transition-transform duration-300 group-hover:scale-105">
-             <Image 
-              src="/logo.svg" 
-              alt="BlueprintAI Logo" 
+            <Image
+              src="/logo.svg"
+              alt="Transmute Logo"
               fill
               className="object-contain"
               priority
             />
           </div>
           <div>
-            <h1 className="text-lg font-bold text-white tracking-tight">BlueprintAI</h1>
+            <h1 className="text-lg font-bold text-white tracking-tight">
+              Transmute
+            </h1>
             <p className="text-xs text-slate-400 font-medium">Task Manager</p>
           </div>
         </Link>
@@ -89,16 +103,19 @@ export function Sidebar({ projects }: SidebarProps) {
       <div className="px-4 py-3 border-b border-slate-800/50">
         <div className="flex gap-2">
           {(["all", "planning", "in_progress"] as const).map((filter) => {
-            const count = projects.filter(p => {
-               if (filter === "all") return true;
-               if (filter === "planning") return p.status === "draft" || p.status === "in_review";
-               if (filter === "in_progress") {
-                 const isCompleted = p.taskStats.total > 0 && p.taskStats.done === p.taskStats.total;
-                 return p.status === "approved" && !isCompleted;
-               }
-               return false;
+            const count = projects.filter((p) => {
+              if (filter === "all") return true;
+              if (filter === "planning")
+                return p.status === "draft" || p.status === "in_review";
+              if (filter === "in_progress") {
+                const isCompleted =
+                  p.taskStats.total > 0 &&
+                  p.taskStats.done === p.taskStats.total;
+                return p.status === "approved" && !isCompleted;
+              }
+              return false;
             }).length;
-            
+
             return (
               <button
                 key={filter}
@@ -107,16 +124,18 @@ export function Sidebar({ projects }: SidebarProps) {
                   "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-200",
                   sidebarStatusFilter === filter
                     ? "bg-violet-500/20 text-violet-300 ring-1 ring-violet-500/30"
-                    : "text-slate-400 hover:text-slate-200 hover:bg-slate-800/50"
+                    : "text-slate-400 hover:text-slate-200 hover:bg-slate-800/50",
                 )}
               >
                 <span className="capitalize">{filter.replace("_", " ")}</span>
-                <span className={cn(
-                  "px-1.5 py-0.5 text-[10px] rounded-md tabular-nums",
-                  sidebarStatusFilter === filter 
-                    ? "bg-violet-500/30 text-violet-200" 
-                    : "bg-slate-800 text-slate-500"
-                )}>
+                <span
+                  className={cn(
+                    "px-1.5 py-0.5 text-[10px] rounded-md tabular-nums",
+                    sidebarStatusFilter === filter
+                      ? "bg-violet-500/30 text-violet-200"
+                      : "bg-slate-800 text-slate-500",
+                  )}
+                >
                   {count}
                 </span>
               </button>
@@ -127,13 +146,35 @@ export function Sidebar({ projects }: SidebarProps) {
 
       {/* Views Navigation */}
       <div className="px-4 py-3 border-b border-slate-800/50">
-        <h3 className="text-[10px] font-semibold text-slate-500 uppercase tracking-wider mb-2">Views</h3>
+        <h3 className="text-[10px] font-semibold text-slate-500 uppercase tracking-wider mb-2">
+          Views
+        </h3>
         <nav className="space-y-1">
           {[
-            { href: "/today", label: "Today", icon: "M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z", color: "from-amber-500 to-orange-500" },
-            { href: "/upcoming", label: "Upcoming", icon: "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z", color: "from-cyan-500 to-blue-500" },
-            { href: "/calendar", label: "Calendar", icon: "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z", color: "from-purple-500 to-pink-500" },
-            { href: "/reports", label: "Reports", icon: "M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z", color: "from-emerald-500 to-teal-500" },
+            {
+              href: "/today",
+              label: "Today",
+              icon: "M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z",
+              color: "from-amber-500 to-orange-500",
+            },
+            {
+              href: "/upcoming",
+              label: "Upcoming",
+              icon: "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z",
+              color: "from-cyan-500 to-blue-500",
+            },
+            {
+              href: "/calendar",
+              label: "Calendar",
+              icon: "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z",
+              color: "from-purple-500 to-pink-500",
+            },
+            {
+              href: "/reports",
+              label: "Reports",
+              icon: "M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z",
+              color: "from-emerald-500 to-teal-500",
+            },
           ].map((view) => {
             const isActive = pathname === view.href;
             return (
@@ -144,20 +185,27 @@ export function Sidebar({ projects }: SidebarProps) {
                   "flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200 group",
                   isActive
                     ? "bg-slate-800 text-white"
-                    : "text-slate-400 hover:bg-slate-800/50 hover:text-slate-200"
+                    : "text-slate-400 hover:bg-slate-800/50 hover:text-slate-200",
                 )}
               >
-                <div className={cn(
-                  "w-6 h-6 rounded-md flex items-center justify-center bg-gradient-to-br",
-                  isActive ? view.color : "from-slate-700 to-slate-600"
-                )}>
+                <div
+                  className={cn(
+                    "w-6 h-6 rounded-md flex items-center justify-center bg-gradient-to-br",
+                    isActive ? view.color : "from-slate-700 to-slate-600",
+                  )}
+                >
                   <svg
                     className="w-3.5 h-3.5 text-white"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
                   >
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={view.icon} />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d={view.icon}
+                    />
                   </svg>
                 </div>
                 <span className="text-sm font-medium">{view.label}</span>
@@ -170,130 +218,170 @@ export function Sidebar({ projects }: SidebarProps) {
         </nav>
       </div>
       <div className="flex-1 overflow-y-auto p-4 space-y-4 scrollbar-thin scrollbar-thumb-slate-800 scrollbar-track-transparent">
-        {Object.entries(projectsByWorkspace).map(([workspace, workspaceProjects]) => {
-          const isCollapsed = collapsedWorkspaces[workspace];
-          const isActive = workspaceProjects.some(p => pathname === `/projects/${p.workspace}/${p.slug}`);
-          
-          return (
-            <div 
-              key={workspace} 
-              className={cn(
-                "rounded-xl border transition-all duration-300 overflow-hidden",
-                "bg-slate-900/30 border-slate-800/50",
-                isActive ? "ring-1 ring-slate-700 shadow-lg shadow-black/20" : "hover:border-slate-700"
-              )}
-            >
-              {/* Workspace Header */}
-              <button
-                onClick={() => toggleWorkspace(workspace)}
-                className="w-full flex items-center justify-between p-3 cursor-pointer hover:bg-slate-800/50 transition-colors group"
-              >
-                <div className="flex items-center gap-3">
-                  <div className={cn(
-                    "w-8 h-8 rounded-lg flex items-center justify-center bg-linear-to-br shadow-inner",
-                    getWorkspaceColor(workspace)
-                  )}>
-                    <span className="text-white text-xs font-bold uppercase">
-                      {workspace.substring(0, 2)}
-                    </span>
-                  </div>
-                  <div className="text-left">
-                    <h2 className="text-sm font-semibold text-slate-200 capitalize tracking-wide group-hover:text-white transition-colors">
-                      {workspace}
-                    </h2>
-                    <span className="text-[10px] text-slate-500">{workspaceProjects.length} projects</span>
-                  </div>
-                </div>
-                
-                <svg
-                  className={cn(
-                    "w-4 h-4 text-slate-500 transition-transform duration-300",
-                    isCollapsed ? "-rotate-90" : "rotate-0"
-                  )}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                </svg>
-              </button>
+        {Object.entries(projectsByWorkspace).map(
+          ([workspace, workspaceProjects]) => {
+            const isCollapsed = collapsedWorkspaces[workspace];
+            const isActive = workspaceProjects.some(
+              (p) => pathname === `/projects/${p.workspace}/${p.slug}`,
+            );
 
-              {/* Workspace Projects (Collapsible) */}
-              <div 
+            return (
+              <div
+                key={workspace}
                 className={cn(
-                  "grid transition-all duration-300 ease-in-out",
-                  isCollapsed ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100"
+                  "rounded-xl border transition-all duration-300 overflow-hidden",
+                  "bg-slate-900/30 border-slate-800/50",
+                  isActive
+                    ? "ring-1 ring-slate-700 shadow-lg shadow-black/20"
+                    : "hover:border-slate-700",
                 )}
               >
-                <div className="overflow-hidden">
-                  <nav className="p-2 pt-0 space-y-1">
-                    {workspaceProjects.map((project) => {
-                      const isProjectActive = pathname === `/projects/${project.workspace}/${project.slug}`;
-                      const progress = project.taskStats.total > 0
-                        ? Math.round((project.taskStats.done / project.taskStats.total) * 100)
-                        : 0;
+                {/* Workspace Header */}
+                <button
+                  onClick={() => toggleWorkspace(workspace)}
+                  className="w-full flex items-center justify-between p-3 cursor-pointer hover:bg-slate-800/50 transition-colors group"
+                >
+                  <div className="flex items-center gap-3">
+                    <div
+                      className={cn(
+                        "w-8 h-8 rounded-lg flex items-center justify-center bg-linear-to-br shadow-inner",
+                        getWorkspaceColor(workspace),
+                      )}
+                    >
+                      <span className="text-white text-xs font-bold uppercase">
+                        {workspace.substring(0, 2)}
+                      </span>
+                    </div>
+                    <div className="text-left">
+                      <h2 className="text-sm font-semibold text-slate-200 capitalize tracking-wide group-hover:text-white transition-colors">
+                        {workspace}
+                      </h2>
+                      <span className="text-[10px] text-slate-500">
+                        {workspaceProjects.length} projects
+                      </span>
+                    </div>
+                  </div>
 
-                      return (
-                        <Link
-                          key={`${project.workspace}-${project.slug}`}
-                          href={`/projects/${project.workspace}/${project.slug}`}
-                          className={cn(
-                            "group block p-2.5 rounded-lg transition-all duration-200 relative overflow-hidden",
-                            isProjectActive
-                              ? "bg-slate-800 text-white shadow-md shadow-black/10"
-                              : "text-slate-400 hover:bg-slate-800/50 hover:text-slate-200"
-                          )}
-                        >
-                          {isProjectActive && (
-                            <div className="absolute left-0 top-0 bottom-0 w-1 bg-violet-500" />
-                          )}
-                          
-                          <div className="flex items-center justify-between gap-2 mb-1.5 pl-2">
-                            <span className="text-sm font-medium truncate">
-                              {project.title}
-                            </span>
-                            <span
-                              className={cn(
-                                "w-1.5 h-1.5 rounded-full shrink-0",
-                                statusColors[project.status]
-                              )}
-                            />
-                          </div>
-                          
-                          {/* Mini Progress bar */}
-                          <div className="pl-2 flex items-center gap-2 opacity-60 group-hover:opacity-100 transition-opacity">
-                            <div className="flex-1 h-1 bg-slate-700/50 rounded-full overflow-hidden">
-                              <div
+                  <svg
+                    className={cn(
+                      "w-4 h-4 text-slate-500 transition-transform duration-300",
+                      isCollapsed ? "-rotate-90" : "rotate-0",
+                    )}
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </button>
+
+                {/* Workspace Projects (Collapsible) */}
+                <div
+                  className={cn(
+                    "grid transition-all duration-300 ease-in-out",
+                    isCollapsed
+                      ? "grid-rows-[0fr] opacity-0"
+                      : "grid-rows-[1fr] opacity-100",
+                  )}
+                >
+                  <div className="overflow-hidden">
+                    <nav className="p-2 pt-0 space-y-1">
+                      {workspaceProjects.map((project) => {
+                        const isProjectActive =
+                          pathname ===
+                          `/projects/${project.workspace}/${project.slug}`;
+                        const progress =
+                          project.taskStats.total > 0
+                            ? Math.round(
+                                (project.taskStats.done /
+                                  project.taskStats.total) *
+                                  100,
+                              )
+                            : 0;
+
+                        return (
+                          <Link
+                            key={`${project.workspace}-${project.slug}`}
+                            href={`/projects/${project.workspace}/${project.slug}`}
+                            className={cn(
+                              "group block p-2.5 rounded-lg transition-all duration-200 relative overflow-hidden",
+                              isProjectActive
+                                ? "bg-slate-800 text-white shadow-md shadow-black/10"
+                                : "text-slate-400 hover:bg-slate-800/50 hover:text-slate-200",
+                            )}
+                          >
+                            {isProjectActive && (
+                              <div className="absolute left-0 top-0 bottom-0 w-1 bg-violet-500" />
+                            )}
+
+                            <div className="flex items-center justify-between gap-2 mb-1.5 pl-2">
+                              <span className="text-sm font-medium truncate">
+                                {project.title}
+                              </span>
+                              <span
                                 className={cn(
-                                  "h-full rounded-full transition-all duration-500",
-                                  isProjectActive ? "bg-violet-500" : "bg-slate-500"
+                                  "w-1.5 h-1.5 rounded-full shrink-0",
+                                  statusColors[project.status],
                                 )}
-                                style={{ width: `${progress}%` }}
                               />
                             </div>
-                            <span className="text-[10px] tabular-nums">
-                              {progress}%
-                            </span>
-                          </div>
-                        </Link>
-                      );
-                    })}
-                  </nav>
+
+                            {/* Mini Progress bar */}
+                            <div className="pl-2 flex items-center gap-2 opacity-60 group-hover:opacity-100 transition-opacity">
+                              <div className="flex-1 h-1 bg-slate-700/50 rounded-full overflow-hidden">
+                                <div
+                                  className={cn(
+                                    "h-full rounded-full transition-all duration-500",
+                                    isProjectActive
+                                      ? "bg-violet-500"
+                                      : "bg-slate-500",
+                                  )}
+                                  style={{ width: `${progress}%` }}
+                                />
+                              </div>
+                              <span className="text-[10px] tabular-nums">
+                                {progress}%
+                              </span>
+                            </div>
+                          </Link>
+                        );
+                      })}
+                    </nav>
+                  </div>
                 </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          },
+        )}
 
         {filteredProjects.length === 0 && (
           <div className="flex flex-col items-center justify-center py-12 px-4 text-center border border-dashed border-slate-800 rounded-xl bg-slate-900/20">
             <div className="w-12 h-12 rounded-full bg-slate-800 flex items-center justify-center mb-3">
-               <svg className="w-6 h-6 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-               </svg>
+              <svg
+                className="w-6 h-6 text-slate-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+                />
+              </svg>
             </div>
-            <p className="text-sm font-medium text-slate-400">No projects found</p>
-            <p className="text-xs text-slate-500 mt-1">Check your filters or create one.</p>
+            <p className="text-sm font-medium text-slate-400">
+              No projects found
+            </p>
+            <p className="text-xs text-slate-500 mt-1">
+              Check your filters or create one.
+            </p>
           </div>
         )}
       </div>
@@ -301,13 +389,13 @@ export function Sidebar({ projects }: SidebarProps) {
       {/* Footer */}
       <div className="p-4 border-t border-slate-800 bg-slate-900/50 backdrop-blur-sm">
         <div className="flex items-center gap-3">
-            <div className="w-8 h-8 rounded-full bg-linear-to-br from-indigo-500 to-violet-500 flex items-center justify-center text-white text-xs font-bold">
-                AI
-            </div>
-            <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-white truncate">AI Agent</p>
-                <p className="text-xs text-slate-500 truncate">Online</p>
-            </div>
+          <div className="w-8 h-8 rounded-full bg-linear-to-br from-indigo-500 to-violet-500 flex items-center justify-center text-white text-xs font-bold">
+            AI
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-white truncate">AI Agent</p>
+            <p className="text-xs text-slate-500 truncate">Online</p>
+          </div>
         </div>
       </div>
     </aside>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "blueprint-ai-monorepo",
+  "name": "transmute-monorepo",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/projects/blueprint-ai/agent-communication/prd.md
+++ b/projects/blueprint-ai/agent-communication/prd.md
@@ -2,9 +2,9 @@
 id: agent-communication
 title: External Agent Communication API
 status: draft
-version: '1.0'
-created_at: '2026-01-06'
-updated_at: '2026-01-06'
+version: "1.0"
+created_at: "2026-01-06"
+updated_at: "2026-01-06"
 author: ai-agent
 ---
 
@@ -12,39 +12,42 @@ author: ai-agent
 
 ## Objective
 
-Establish a secure and standardized interface to allow external AI agents (from other projects or systems) to interact with the BlueprintAI project management system. The primary goal is to enable these agents to read project context and create or update tasks autonomously.
+Establish a secure and standardized interface to allow external AI agents (from other projects or systems) to interact with the Transmute project management system. The primary goal is to enable these agents to read project context and create or update tasks autonomously.
 
 ## Context
 
-Currently, the system is closed to external programmatic access. As the ecosystem grows, agents working in other repositories need a way to report progress or request actions within BlueprintAI without manual human intervention.
+Currently, the system is closed to external programmatic access. As the ecosystem grows, agents working in other repositories need a way to report progress or request actions within Transmute without manual human intervention.
 
 ## Functional Requirements
 
 ### Authentication
+
 1.  **API Key**: Simple Bearer token authentication for external agents.
 2.  **Security**: Keys should be managed via environment variables initially. The key is bound to a specific Workspace.
 
 ### API Endpoints
+
 1.  **List Projects**: `GET /api/external/workspaces/:workspaceSlug/projects` - To discover available context.
 2.  **List Tasks**: `GET /api/external/workspaces/:workspaceSlug/projects/:projectSlug/tasks` - To see what needs to be done.
 3.  **Create Task**: `POST /api/external/workspaces/:workspaceSlug/projects/:projectSlug/tasks` - To add new work items.
 4.  **Update Task**: `PATCH /api/external/tasks/:taskId` - To report progress (toggle status, add comments/descriptions).
 
 ### Data Format
--   **JSON**: All exchanges should be in strict JSON format.
--   **Schema**: Responses should adhere to the existing Zod schemas defined in `@repo/schemas`.
+
+- **JSON**: All exchanges should be in strict JSON format.
+- **Schema**: Responses should adhere to the existing Zod schemas defined in `@repo/schemas`.
 
 ## Non-Functional Requirements
 
--   **Security**: Prevent unauthorized access to write operations.
--   **Documentation**: Provide an OpenAPI specification (or simple equivalent) so LLMs can easily understand how to use the API.
--   **Error Handling**: Clear error messages (4xx, 5xx) to help agents correct their requests.
+- **Security**: Prevent unauthorized access to write operations.
+- **Documentation**: Provide an OpenAPI specification (or simple equivalent) so LLMs can easily understand how to use the API.
+- **Error Handling**: Clear error messages (4xx, 5xx) to help agents correct their requests.
 
 ## Out of Scope
 
--   Webhooks (agents receiving push notifications).
--   Complex user management (ACLs per project).
--   Real-time socket communication.
+- Webhooks (agents receiving push notifications).
+- Complex user management (ACLs per project).
+- Real-time socket communication.
 
 ## Success Metrics
 

--- a/projects/blueprint-ai/agent-communication/tasks.md
+++ b/projects/blueprint-ai/agent-communication/tasks.md
@@ -1,13 +1,14 @@
 ---
 project_id: agent-communication
-prd_version: '1.0'
-created_at: '2026-01-06'
-updated_at: '2026-01-06'
+prd_version: "1.0"
+created_at: "2026-01-06"
+updated_at: "2026-01-06"
 ---
 
 # Tasks: External Agent Communication API
 
 ## Task 1: Auth and Core API
+
 - **id:** task-agent-101
 - **status:** todo
 - **priority:** critical
@@ -16,17 +17,21 @@ updated_at: '2026-01-06'
 ### Subtasks
 
 #### [ ] Implement Auth Middleware
-Create a `validateApiKey` function that checks the `Authorization` header against `process.env.BLUEPRINT_API_KEY`.
+
+Create a `validateApiKey` function that checks the `Authorization` header against `process.env.TRANSMUTE_API_KEY`.
 
 #### [ ] Define API Schemas
+
 Create Zod schemas for the external API requests/responses (if different from internal ones).
 
 #### [ ] Create Project Endpoints
+
 Implement `GET /api/external/projects` and `GET /api/external/projects/:slug` to expose read-only context.
 
 ---
 
 ## Task 2: Task Management Endpoints
+
 - **id:** task-agent-102
 - **status:** todo
 - **priority:** high
@@ -35,17 +40,21 @@ Implement `GET /api/external/projects` and `GET /api/external/projects/:slug` to
 ### Subtasks
 
 #### [ ] Implement Create Task
+
 Create `POST /api/external/projects/:slug/tasks` handler. Needs to append to `tasks.md`.
 
 #### [ ] Implement Update Task
+
 Create `PATCH /api/external/tasks/:taskId` handler. Needs to update specific task in `tasks.md`.
 
 #### [ ] Validate Inputs
+
 Ensure agents cannot inject malformed Markdown or corrupt the file structure.
 
 ---
 
 ## Task 3: Documentation and Testing
+
 - **id:** task-agent-103
 - **status:** todo
 - **priority:** medium
@@ -54,7 +63,9 @@ Ensure agents cannot inject malformed Markdown or corrupt the file structure.
 ### Subtasks
 
 #### [ ] Generate OpenAPI Spec
+
 Create a `openapi.json` route or static file describing the external API.
 
 #### [ ] Integration Tests
+
 Write a script acting as an "external agent" to verify the full flow (Auth -> List -> Create -> Update).

--- a/projects/blueprint-ai/agent-guidelines/prd.md
+++ b/projects/blueprint-ai/agent-guidelines/prd.md
@@ -11,9 +11,11 @@ author: "antigravity"
 # Agent Guidelines Improvements
 
 ## Objetivo
-Refinar e expandir as diretrizes para os agentes de IA que trabalham no projeto BlueprintAI. O objetivo é garantir maior consistência, transparência e controle na execução das tarefas, além de permitir uma comunicação mais rica sobre o status e bloqueios.
+
+Refinar e expandir as diretrizes para os agentes de IA que trabalham no projeto Transmute. O objetivo é garantir maior consistência, transparência e controle na execução das tarefas, além de permitir uma comunicação mais rica sobre o status e bloqueios.
 
 ## Requisitos Funcionais
+
 1.  **Monitoramento de Status**: Agentes devem sinalizar início (`in_progress`) e fim (`done`) de tarefas explicitamente.
 2.  **Verificação de Conclusão**: Agentes devem pedir confirmação se tiverem incerteza antes de marcar como feito.
 3.  **Controle de Escopo**: Novas solicitações em itens já concluídos devem gerar novas tasks, não alterações nas antigas.

--- a/projects/blueprint-ai/documentation-site/prd.md
+++ b/projects/blueprint-ai/documentation-site/prd.md
@@ -2,9 +2,9 @@
 id: documentation-site
 title: Documentation Site
 status: draft
-version: '1.1'
-created_at: '2026-01-05'
-updated_at: '2026-01-05'
+version: "1.1"
+created_at: "2026-01-05"
+updated_at: "2026-01-05"
 author: ai-agent
 ---
 
@@ -12,7 +12,7 @@ author: ai-agent
 
 ## Objective
 
-Create a dedicated documentation site for BlueprintAI, separate from the main application. The goal is to provide a complete and professional guide for users and developers, facilitating project adoption and contribution.
+Create a dedicated documentation site for Transmute, separate from the main application. The goal is to provide a complete and professional guide for users and developers, facilitating project adoption and contribution.
 
 ## Context
 
@@ -21,14 +21,16 @@ Currently, documentation is scattered across Markdown files within the repositor
 ## Functional Requirements
 
 ### Documentation Platform
+
 1. **Framework**: Use **Fumadocs** (Next.js App Router).
 2. **Content Structure**:
    - **Getting Started**: Installation, local configuration, and "Hello World".
-   - **User Guide**: How to create PRDs, Tasks, and use BlueprintAI features.
+   - **User Guide**: How to create PRDs, Tasks, and use Transmute features.
    - **Agent Reference**: Technical documentation of schemas and standards. **Note:** The `AGENTS.md` file will be kept in the root for LLM consumption; the site will serve as a visualization for humans.
    - **API Reference**: Documentation of internal endpoints (e.g., task updates).
 
 ### Site Features
+
 1. **Full-text Search**: Indexing of all content using Fumadocs search.
 2. **Dark Mode**: Support for dark theme, aligned with the main app's visual identity.
 3. **MDX**: Support for React components and TypeTable for props/schema documentation.
@@ -37,7 +39,7 @@ Currently, documentation is scattered across Markdown files within the repositor
 ## Non-Functional Requirements
 
 - **Performance**: The site must load instantly (Next.js SSG/SSR).
-- **Design**: Maintain visual consistency with BlueprintAI (violet/dark color palette).
+- **Design**: Maintain visual consistency with Transmute (violet/dark color palette).
 - **Maintainability**: Content written in MDX.
 - **Visual Richness**: Prioritize inclusion of screenshots/GIFs whenever describing UI functionalities.
 

--- a/projects/blueprint-ai/documentation-site/tasks.md
+++ b/projects/blueprint-ai/documentation-site/tasks.md
@@ -1,13 +1,14 @@
 ---
 project_id: documentation-site
-prd_version: '1.1'
-created_at: '2026-01-05'
-updated_at: '2026-01-06'
+prd_version: "1.1"
+created_at: "2026-01-05"
+updated_at: "2026-01-06"
 ---
 
 # Tasks: Documentation Site
 
 ## Task 1: Docs Project Setup
+
 - **id:** task-101
 - **status:** done
 - **priority:** high
@@ -16,17 +17,21 @@ updated_at: '2026-01-06'
 ### Subtasks
 
 #### [x] Initialize Fumadocs project
+
 Create initial project structure using Fumadocs CLI (`create-fumadocs-app`).
 
 #### [x] Configure project metadata
+
 Update `source.config.ts` or similar to define title, description, and file structure.
 
 #### [x] Configure theme (Tailwind CSS)
-Adjust Tailwind colors to use BlueprintAI's violet/dark theme.
+
+Adjust Tailwind colors to use Transmute's violet/dark theme.
 
 ---
 
 ## Task 2: Content Migration and Creation
+
 - **id:** task-102
 - **status:** done
 - **priority:** high
@@ -35,20 +40,25 @@ Adjust Tailwind colors to use BlueprintAI's violet/dark theme.
 ### Subtasks
 
 #### [x] Migrate Getting Started
+
 Create `content/docs/index.mdx` page with introduction and setup (based on README).
 
 #### [x] Create "Core Concepts" Guide
+
 Document PRD -> Tasks flow and `projects/` directory structure.
 
 #### [x] Create Schema Reference
+
 Document Zod schemas and frontmatter (based on `AGENTS.md`) using TypeTable if possible.
 
 #### [x] Create API Guide
+
 Document endpoints like `PATCH /api/tasks/[taskId]` using OpenAPI or manual MDX.
 
 ---
 
 ## Task 3: Integration and Deploy
+
 - **id:** task-103
 - **status:** done
 - **priority:** medium
@@ -57,11 +67,13 @@ Document endpoints like `PATCH /api/tasks/[taskId]` using OpenAPI or manual MDX.
 ### Subtasks
 
 #### [x] Configure Search
+
 Verify indexing and functionality of Fumadocs search.
 
 #### [x] SEO Review
+
 Add appropriate meta tags and descriptions.
 
 #### [x] Validate cross-links
-Ensure all internal links work correctly.
 
+Ensure all internal links work correctly.

--- a/projects/blueprint-ai/integrations/prd.md
+++ b/projects/blueprint-ai/integrations/prd.md
@@ -2,9 +2,9 @@
 id: integrations
 title: Third-Party Integrations
 status: draft
-version: '1.0'
-created_at: '2026-01-06'
-updated_at: '2026-01-06'
+version: "1.0"
+created_at: "2026-01-06"
+updated_at: "2026-01-06"
 author: ai-agent
 ---
 
@@ -12,7 +12,7 @@ author: ai-agent
 
 ## Objective
 
-Connect BlueprintAI with external tools to enable data synchronization and export capabilities.
+Connect Transmute with external tools to enable data synchronization and export capabilities.
 
 ## Context
 
@@ -21,11 +21,11 @@ Users often use specialized tools for issue tracking (Jira, Linear) or code mana
 ## Functional Requirements
 
 1.  **Exports**:
-    -   Export tasks to GitHub Issues.
-    -   Export tasks to Jira.
-    -   Export tasks to Linear.
-    -   Bulk export to CSV/JSON.
+    - Export tasks to GitHub Issues.
+    - Export tasks to Jira.
+    - Export tasks to Linear.
+    - Bulk export to CSV/JSON.
 
 ## Success Metrics
 
-1.  One-click export of a BlueprintAI project to a GitHub Repository (creating issues).
+1.  One-click export of a Transmute project to a GitHub Repository (creating issues).

--- a/projects/blueprint-ai/integrations/tasks.md
+++ b/projects/blueprint-ai/integrations/tasks.md
@@ -1,13 +1,14 @@
 ---
 project_id: integrations
-prd_version: '1.0'
-created_at: '2026-01-06'
-updated_at: '2026-01-06'
+prd_version: "1.0"
+created_at: "2026-01-06"
+updated_at: "2026-01-06"
 ---
 
 # Tasks: Third-Party Integrations
 
 ## Task 1: GitHub Integration
+
 - **id:** task-int-101
 - **status:** todo
 - **priority:** medium
@@ -16,17 +17,21 @@ updated_at: '2026-01-06'
 ### Subtasks
 
 #### [ ] Research GitHub API
+
 Verify scopes needed for issue creation.
 
 #### [ ] OAuth Flow / Token Input
+
 Allow user to input PAT or authenticate via OAuth.
 
 #### [ ] Sync Logic
+
 Map Task -> Issue, Subtask -> Checklist (or separate issues).
 
 ---
 
 ## Task 2: Linear Integration
+
 - **id:** task-int-102
 - **status:** todo
 - **priority:** medium
@@ -35,14 +40,17 @@ Map Task -> Issue, Subtask -> Checklist (or separate issues).
 ### Subtasks
 
 #### [ ] Research Linear API
+
 Understanding GraphQL API and Project/Issue mapping.
 
 #### [ ] Export Implementation
+
 Create Linear Project and Issues from Markdown data.
 
 ---
 
 ## Task 3: Jira Integration
+
 - **id:** task-int-103
 - **status:** todo
 - **priority:** medium
@@ -51,7 +59,9 @@ Create Linear Project and Issues from Markdown data.
 ### Subtasks
 
 #### [ ] Research Jira API
+
 Verify Cloud API specifics (Atlassian Connect or OAuth 2.0).
 
 #### [ ] Map Fields
-Map BlueprintAI Priority/Status to Jira fields.
+
+Map Transmute Priority/Status to Jira fields.

--- a/projects/blueprint-ai/mcp-server/prd.md
+++ b/projects/blueprint-ai/mcp-server/prd.md
@@ -2,9 +2,9 @@
 id: mcp-server
 title: MCP Server Integration
 status: draft
-version: '1.0'
-created_at: '2026-01-11'
-updated_at: '2026-01-11'
+version: "1.0"
+created_at: "2026-01-11"
+updated_at: "2026-01-11"
 author: ai-agent
 ---
 
@@ -12,34 +12,34 @@ author: ai-agent
 
 ## Objective
 
-Transform BlueprintAI into a central task management hub by implementing the Model Context Protocol (MCP). This allows other AI agents (using MCP clients like Claude Desktop, Cursor, etc.) to asynchronously read, create, and update tasks within the system.
+Transform Transmute into a central task management hub by implementing the Model Context Protocol (MCP). This allows other AI agents (using MCP clients like Claude Desktop, Cursor, etc.) to asynchronously read, create, and update tasks within the system.
 
 ## Context
 
-The user envisions BlueprintAI as the "center of tasks" where multiple agents work in parallel on non-conflicting tasks. To achieve this, we need a standard protocol for these agents to interface with the BlueprintAI file system and logic without manual human intervention.
+The user envisions Transmute as the "center of tasks" where multiple agents work in parallel on non-conflicting tasks. To achieve this, we need a standard protocol for these agents to interface with the Transmute file system and logic without manual human intervention.
 
 ## Functional Requirements
 
 1.  **MCP Server Infrastructure**:
-    -   Implement a local MCP server (using `@modelcontextprotocol/sdk`).
-    -   Transport: Stdio (standard input/output) for local agent integration.
+    - Implement a local MCP server (using `@modelcontextprotocol/sdk`).
+    - Transport: Stdio (standard input/output) for local agent integration.
 
 2.  **Resources (Read Capabilities)**:
-    -   Expose `projects` as resources.
-    -   Expose `prd.md` and `tasks.md` files as readable resources.
-    -   URI Scheme: `blueprint://<project-slug>/tasks`
+    - Expose `projects` as resources.
+    - Expose `prd.md` and `tasks.md` files as readable resources.
+    - URI Scheme: `blueprint://<project-slug>/tasks`
 
 3.  **Tools (Write/Action Capabilities)**:
-    -   `list_projects`: List available projects.
-    -   `create_task`: Add a new task to a specific project.
-    -   `update_task_status`: Mark tasks as in_progress, done, etc.
-    -   `add_task_comment`: Append comments/notes to a task.
+    - `list_projects`: List available projects.
+    - `create_task`: Add a new task to a specific project.
+    - `update_task_status`: Mark tasks as in_progress, done, etc.
+    - `add_task_comment`: Append comments/notes to a task.
 
 4.  **Prompts (Agentic Workflows)**:
-    -   `get_next_task`: A prompt that helps an agent pick the next high-priority todo task from a specific project.
+    - `get_next_task`: A prompt that helps an agent pick the next high-priority todo task from a specific project.
 
 ## Success Metrics
 
-1.  An external agent (e.g., via Claude Desktop) can connect to BlueprintAI MCP.
+1.  An external agent (e.g., via Claude Desktop) can connect to Transmute MCP.
 2.  The agent can read the list of tasks.
 3.  The agent can mark a task as "done" and it updates the local markdown file.

--- a/projects/blueprint-ai/mcp-server/tasks.md
+++ b/projects/blueprint-ai/mcp-server/tasks.md
@@ -1,13 +1,14 @@
 ---
 project_id: mcp-server
-prd_version: '1.0'
-created_at: '2026-01-11'
-updated_at: '2026-01-11'
+prd_version: "1.0"
+created_at: "2026-01-11"
+updated_at: "2026-01-11"
 ---
 
 # Tasks: MCP Server Integration
 
 ## Task 1: Server Initialization
+
 - **id:** mcp-001
 - **status:** todo
 - **priority:** high
@@ -16,36 +17,44 @@ updated_at: '2026-01-11'
 ### Subtasks
 
 #### [ ] Create Package
+
 Create `apps/mcp-server` (or `packages/mcp-server` if it's a library, but likely an app/service). Use `@modelcontextprotocol/sdk`.
 
 #### [ ] Configure Build
+
 Update `turbo.json` and `package.json` to include the new app in the workspace.
 
 #### [ ] Basic Server
+
 Implement a simple "Hello World" MCP server over Stdio to verify connectivity.
 
 ---
 
 ## Task 2: Resource Implementation (Read)
+
 - **id:** mcp-002
 - **status:** todo
 - **priority:** high
-- **description:** Expose BlueprintAI projects and tasks as MCP Resources.
+- **description:** Expose Transmute projects and tasks as MCP Resources.
 
 ### Subtasks
 
 #### [ ] Project List Resource
+
 Implement `blueprint://projects` to return a JSON list of all available projects.
 
 #### [ ] Task List Resource
+
 Implement `blueprint://<project-slug>/tasks` to return the content of `tasks.md`.
 
 #### [ ] PRD Resource
+
 Implement `blueprint://<project-slug>/prd` to return the content of `prd.md`.
 
 ---
 
 ## Task 3: Tool Implementation (Write)
+
 - **id:** mcp-003
 - **status:** todo
 - **priority:** high
@@ -54,20 +63,24 @@ Implement `blueprint://<project-slug>/prd` to return the content of `prd.md`.
 ### Subtasks
 
 #### [ ] `create_task` Tool
+
 Inputs: `projectId`, `title`, `description`, `priority`.
 Logic: Appends a new task to `tasks.md`.
 
 #### [ ] `update_task_status` Tool
+
 Inputs: `projectId`, `taskId`, `status`.
 Logic: Finds the task by ID and updates its status field.
 
 #### [ ] `add_comment` Tool
+
 Inputs: `projectId`, `taskId`, `content`.
 Logic: Appends a comment to the task.
 
 ---
 
 ## Task 4: Agentic Prompts
+
 - **id:** mcp-004
 - **status:** todo
 - **priority:** medium
@@ -76,6 +89,7 @@ Logic: Appends a comment to the task.
 ### Subtasks
 
 #### [ ] `get_next_important_task`
+
 Prompt logic: "Read all projects, find 'high' priority 'todo' tasks, and return the top 3."
 
 ---

--- a/projects/blueprint-ai/monorepo-infra/prd.md
+++ b/projects/blueprint-ai/monorepo-infra/prd.md
@@ -2,9 +2,9 @@
 id: monorepo-infra
 title: Monorepo Infrastructure
 status: draft
-version: '1.0'
-created_at: '2026-01-05'
-updated_at: '2026-01-05'
+version: "1.0"
+created_at: "2026-01-05"
+updated_at: "2026-01-05"
 author: ai-agent
 ---
 
@@ -12,7 +12,7 @@ author: ai-agent
 
 ## Objective
 
-Migrate the BlueprintAI project structure to a scalable monorepo using Turborepo, allowing the coexistence of the current Web App and the future Documentation Site, with efficient sharing of code and configurations.
+Migrate the Transmute project structure to a scalable monorepo using Turborepo, allowing the coexistence of the current Web App and the future Documentation Site, with efficient sharing of code and configurations.
 
 ## Context
 
@@ -21,6 +21,7 @@ Migration is a prerequisite for the development of the documentation site. We ne
 ## Functional Requirements
 
 ### Monorepo Structure
+
 1. **Turborepo**: Root configuration with `turbo.json` for script orchestration.
 2. **Package Manager**: Use `pnpm workspaces` for dependency management.
 3. **Workspace Organization**:
@@ -29,6 +30,7 @@ Migration is a prerequisite for the development of the documentation site. We ne
    - `packages/*`: Shared libraries.
 
 ### Shared Packages
+
 1. **`packages/ui`**: Shared base UI components (shadcn/ui).
 2. **`packages/schemas`**: Zod schemas (PRD, Tasks) to be used by both the app and documentation.
 3. **`packages/utils`**: Utility functions (formatters, parsers).

--- a/projects/blueprint-ai/monorepo-infra/tasks.md
+++ b/projects/blueprint-ai/monorepo-infra/tasks.md
@@ -1,13 +1,14 @@
 ---
 project_id: monorepo-infra
-prd_version: '1.0'
-created_at: '2026-01-05'
-updated_at: '2026-01-05'
+prd_version: "1.0"
+created_at: "2026-01-05"
+updated_at: "2026-01-05"
 ---
 
 # Tasks: Monorepo Infrastructure
 
 ## Task 1: Workspace Setup
+
 - **id:** task-201
 - **status:** done
 - **priority:** critical
@@ -16,17 +17,21 @@ updated_at: '2026-01-05'
 ### Subtasks
 
 #### [x] Configure pnpm workspaces
+
 Create `pnpm-workspace.yaml` defining `apps/*` and `packages/*`.
 
 #### [x] Initialize Turborepo
+
 Create `turbo.json` with `build`, `dev`, `lint` pipelines.
 
 #### [x] Adjust root package.json
+
 Define global scripts and remove dependencies that will be moved to apps.
 
 ---
 
 ## Task 2: Configuration Extraction
+
 - **id:** task-202
 - **status:** done
 - **priority:** high
@@ -35,17 +40,21 @@ Define global scripts and remove dependencies that will be moved to apps.
 ### Subtasks
 
 #### [x] Create packages/tsconfig
+
 Package with `tsconfig.base.json` and `tsconfig.next.json`.
 
 #### [x] Create packages/eslint-config
+
 Package with base ESLint/Prettier configuration.
 
 #### [x] Create packages/tailwind-config
-Package with Tailwind preset (BlueprintAI colors, fonts).
+
+Package with Tailwind preset (Transmute colors, fonts).
 
 ---
 
 ## Task 3: Web App Migration
+
 - **id:** task-203
 - **status:** done
 - **priority:** critical
@@ -54,17 +63,21 @@ Package with Tailwind preset (BlueprintAI colors, fonts).
 ### Subtasks
 
 #### [x] Move files
+
 Move `src/`, `public/`, and config files to `apps/web`.
 
 #### [x] Adjust internal imports
+
 Fix relative paths and aliases (`@/*`).
 
 #### [x] Validate isolated execution
+
 Ensure the app runs correctly within the new location.
 
 ---
 
 ## Task 4: Shared Code Extraction
+
 - **id:** task-204
 - **status:** done
 - **priority:** medium
@@ -73,10 +86,13 @@ Ensure the app runs correctly within the new location.
 ### Subtasks
 
 #### [x] Extract packages/schemas
+
 Move Zod definitions to shared package.
 
 #### [x] Extract packages/utils
+
 Move generic helpers.
 
 #### [x] Refactor Web App to use packages
+
 Replace local imports with `@blueprint/schemas` and `@blueprint/utils` imports.


### PR DESCRIPTION
## Summary

Complete system rename from BlueprintAI to Transmute across the entire codebase.

## Changes

- **UI Text**: All user-facing "BlueprintAI" references → "Transmute"
- **Package name**: `blueprint-ai-monorepo` → `transmute-monorepo`
- **Metadata**: Page titles, OpenGraph, Twitter cards updated
- **Docs site**: All Fumadocs content and layout updated
- **Environment variables**: `BLUEPRINT_API_KEY` → `TRANSMUTE_API_KEY` (reference only)
- **Project content**: PRD and task files updated with new branding

## Files Modified (24 total)

- Root: `AGENTS.md`, `README.md`, `package.json`
- Web app: `apps/web/src/components/sidebar.tsx`, `apps/web/src/app/layout.tsx`
- Docs: Layout, homepage, and all MDX content files
- Projects: All PRD and task markdown files in `projects/blueprint-ai/`

## Notes

- The `projects/blueprint-ai/` directory was **not renamed** to minimize breaking changes
- Logo assets exist in `branding/transmute/` but are not yet integrated (separate task)
- GitHub repo already renamed via `gh repo rename`

## Post-Merge Checklist

- [ ] Update CI/CD environment variables if applicable
- [ ] Verify deploy webhooks work with renamed repo