### PR TITLE
feat: add opencode-transmute PRD and fix hydration mismatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,3 +336,31 @@ After completing a task and creating the PR, the agent MUST perform a **learning
    - `.agent/workflows/` — for repeatable multi-step processes
 
 > **Goal**: Each session should leave behind wisdom for future agents. The guidelines file is a living document that evolves with practical experience.
+
+## Monorepo Development
+
+### Build de Packages Internos
+
+Antes de testar o app (`apps/web`), certifique-se de que os packages internos (`@repo/schemas`, `@repo/utils`) estão buildados:
+
+```bash
+pnpm --filter @repo/schemas build
+pnpm --filter @repo/utils build
+# ou simplesmente
+pnpm build
+```
+
+Os packages apontam para `./dist/` no `package.json`. Se o `dist/` não existir, o Next.js falhará com erros de "Module not found".
+
+## PRD Planning
+
+### Confirmar Decisões de Design
+
+Ao criar PRDs, não assuma decisões de design sem confirmar com o usuário. Exemplos de pontos que requerem confirmação:
+
+- Geração de dados via IA vs lógica determinística
+- Escolha de tecnologias/ferramentas específicas
+- Trade-offs de escopo (MVP vs pós-MVP)
+- Localização de código no monorepo (apps/ vs packages/)
+
+Pergunte explicitamente antes de finalizar o documento.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,26 +283,26 @@ After completing a task and creating the PR, the agent MUST perform a **learning
 
 ## PRD Planning
 
-### Confirmar Decisões de Design
+### Confirm Design Decisions
 
-Ao criar PRDs, não assuma decisões de design sem confirmar com o usuário. Exemplos de pontos que requerem confirmação:
+When creating PRDs, do not assume design decisions without confirming with the user. Examples of points that require confirmation:
 
-- Geração de dados via IA vs lógica determinística
-- Escolha de tecnologias/ferramentas específicas
-- Trade-offs de escopo (MVP vs pós-MVP)
-- Localização de código no monorepo (apps/ vs packages/)
+- AI-generated data vs deterministic logic
+- Choice of specific technologies/tools
+- Scope trade-offs (MVP vs post-MVP)
+- Code location in the monorepo (apps/ vs packages/)
 
-Pergunte explicitamente antes de finalizar o documento.
+Ask explicitly before finalizing the document.
 
-### Usar Modo Interativo para Decisões
+### Use Interactive Mode for Decisions
 
-Quando houver decisões de design que precisam de definição explícita do usuário, **use o modo interativo do terminal** (tool `question`) para apresentar as opções.
+When there are design decisions that need explicit user input, **use the terminal interactive mode** (`question` tool) to present the options.
 
-Exemplos de quando usar:
+Examples of when to use:
 
-- Escolher entre abordagens técnicas (IA vs determinístico)
-- Definir escopo (MVP vs pós-MVP)
-- Selecionar tecnologias/ferramentas
-- Decidir localização de código no monorepo
+- Choosing between technical approaches (AI vs deterministic)
+- Defining scope (MVP vs post-MVP)
+- Selecting technologies/tools
+- Deciding code location in the monorepo
 
-Isso garante que o usuário tome decisões informadas antes de continuar.
+This ensures the user makes informed decisions before proceeding.

--- a/apps/web/src/components/task-list.tsx
+++ b/apps/web/src/components/task-list.tsx
@@ -30,20 +30,23 @@ interface TaskListProps {
 
 export function TaskList({ tasks, workspace, projectSlug }: TaskListProps) {
   const { taskId, setTaskId, filter, setFilter } = useTaskSearchParams();
-  
+
   // Local state for task order - will be synced to backend in Task 2
   const [orderedTasks, setOrderedTasks] = useState<Task[]>(tasks);
-  
+
   // Sync with server data when it changes
   useEffect(() => {
     setOrderedTasks(tasks);
   }, [tasks]);
 
-  const filteredTasks = filter === "all"
-    ? orderedTasks
-    : orderedTasks.filter((task) => task.status === filter);
+  const filteredTasks =
+    filter === "all"
+      ? orderedTasks
+      : orderedTasks.filter((task) => task.status === filter);
 
-  const selectedTask = taskId ? orderedTasks.find(t => t.id === taskId) ?? null : null;
+  const selectedTask = taskId
+    ? (orderedTasks.find((t) => t.id === taskId) ?? null)
+    : null;
 
   // DnD sensors
   const sensors = useSensors(
@@ -54,15 +57,18 @@ export function TaskList({ tasks, workspace, projectSlug }: TaskListProps) {
     }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
-    })
+    }),
   );
 
   // IDs for SortableContext
-  const taskIds = useMemo(() => filteredTasks.map((t) => t.id), [filteredTasks]);
+  const taskIds = useMemo(
+    () => filteredTasks.map((t) => t.id),
+    [filteredTasks],
+  );
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
-    
+
     if (over && active.id !== over.id) {
       setOrderedTasks((items) => {
         const oldIndex = items.findIndex((t) => t.id === active.id);
@@ -75,10 +81,26 @@ export function TaskList({ tasks, workspace, projectSlug }: TaskListProps) {
 
   const filters: { value: typeof filter; label: string; count: number }[] = [
     { value: "all", label: "All", count: orderedTasks.length },
-    { value: "todo", label: "To Do", count: orderedTasks.filter((t) => t.status === "todo").length },
-    { value: "in_progress", label: "In Progress", count: orderedTasks.filter((t) => t.status === "in_progress").length },
-    { value: "done", label: "Done", count: orderedTasks.filter((t) => t.status === "done").length },
-    { value: "blocked", label: "Blocked", count: orderedTasks.filter((t) => t.status === "blocked").length },
+    {
+      value: "todo",
+      label: "To Do",
+      count: orderedTasks.filter((t) => t.status === "todo").length,
+    },
+    {
+      value: "in_progress",
+      label: "In Progress",
+      count: orderedTasks.filter((t) => t.status === "in_progress").length,
+    },
+    {
+      value: "done",
+      label: "Done",
+      count: orderedTasks.filter((t) => t.status === "done").length,
+    },
+    {
+      value: "blocked",
+      label: "Blocked",
+      count: orderedTasks.filter((t) => t.status === "blocked").length,
+    },
   ];
 
   return (
@@ -93,7 +115,7 @@ export function TaskList({ tasks, workspace, projectSlug }: TaskListProps) {
               "px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200",
               filter === f.value
                 ? "bg-violet-600 text-white"
-                : "bg-slate-800 text-slate-400 hover:bg-slate-700 hover:text-white"
+                : "bg-slate-800 text-slate-400 hover:bg-slate-700 hover:text-white",
             )}
           >
             {f.label}
@@ -106,6 +128,7 @@ export function TaskList({ tasks, workspace, projectSlug }: TaskListProps) {
 
       {/* Task list with DnD */}
       <DndContext
+        id="task-list-dnd"
         sensors={sensors}
         collisionDetection={closestCenter}
         onDragEnd={handleDragEnd}

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -2,9 +2,14 @@
   "name": "@repo/schemas",
   "version": "0.0.0",
   "private": true,
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "lint": "eslint ."

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,9 +2,14 @@
   "name": "@repo/utils",
   "version": "0.0.0",
   "private": true,
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "lint": "eslint ."

--- a/projects/blueprint-ai/opencode-transmute/prd.md
+++ b/projects/blueprint-ai/opencode-transmute/prd.md
@@ -1,0 +1,315 @@
+---
+id: opencode-transmute
+title: OpenCode Transmute Plugin
+status: draft
+version: "1.0"
+created_at: "2026-01-17"
+updated_at: "2026-01-17"
+workflow: opencode
+author: ai-agent
+category: plugins
+---
+
+# OpenCode Transmute Plugin
+
+## Objetivo
+
+Criar um **plugin de sistema para o OpenCode** que integre o agente de IA ao **Transmute**, transformando tarefas em **ambientes de execução isolados**, previsíveis e reproduzíveis.
+
+O plugin conecta planejamento e execução ao:
+
+- Transformar features do Transmute em **tools** disponíveis para o OpenCode
+- Criar isolamento real via **Git worktrees**
+- Automatizar setup de ambiente
+- Manter contexto entre sessões
+- Reduzir atrito cognitivo no desenvolvimento assistido por IA
+
+## Problema
+
+Ao trabalhar com agentes de IA no OpenCode em projetos com múltiplas tarefas:
+
+1. **Poluição de workspace**: múltiplas tarefas modificam os mesmos arquivos
+2. **Branches misturadas**: commits de tarefas diferentes se misturam
+3. **Setup repetitivo**: cada sessão exige reconfiguração manual
+4. **Contexto perdido**: ao reiniciar sessões, o agente perde o estado anterior
+5. **Falta de integração**: não há conexão nativa entre OpenCode e sistemas de tarefas
+
+O OpenCode não oferece nativamente um **modelo de sessão isolada por tarefa**, nem ferramentas para integração com Transmute.
+
+## Proposta de Solução
+
+O **opencode-transmute** resolve isso oferecendo:
+
+### MVP (Escopo Principal)
+
+1. **Isolamento por Tarefa**
+   - Criação automática de branch baseada na tarefa
+   - Git worktree dedicado por tarefa
+   - Associação clara: tarefa ↔ branch ↔ worktree
+
+2. **Automação de Ambiente**
+   - Abertura de sessão de terminal (WezTerm)
+   - Execução de hooks declarativos após criação
+   - Logs de execução visíveis
+
+3. **Persistência Mínima**
+   - Estado salvo em `.opencode/transmute.sessions.json`
+   - Apenas dados essenciais: tarefa, branch, worktree, timestamp
+   - Permite retomada e evita duplicações
+
+### Pós-MVP (Iterações Futuras)
+
+1. **Tools de Integração com Transmute**
+   - Buscar tarefas do sistema
+   - Marcar progresso de tarefas
+   - Vincular execução a tarefas
+
+2. **Gestão de Sessões**
+   - Listagem de sessões/worktrees ativos
+   - Retomada assistida de worktrees
+   - Cleanup de worktrees antigos
+
+3. **Extensibilidade**
+   - Integração com tmux
+   - Spawn em nova janela (opcional)
+   - Notificações para sessão principal
+
+## Escopo e Não-Escopo
+
+### Escopo (MVP)
+
+| Item                 | Descrição                               |
+| -------------------- | --------------------------------------- |
+| Branch naming        | Gerar nome de branch baseado em task ID |
+| Git worktree         | Criar worktree isolado para cada tarefa |
+| Terminal session     | Abrir sessão WezTerm na mesma janela    |
+| Hooks                | Executar comandos declarados após setup |
+| Persistência         | Salvar estado mínimo para retomada      |
+| OpenCode integration | Funcionar como plugin/tool do OpenCode  |
+
+### Não-Escopo (MVP)
+
+| Item                    | Razão                                   |
+| ----------------------- | --------------------------------------- |
+| Coordenação multi-agent | Complexidade prematura                  |
+| Serviços externos       | Foco em operação local                  |
+| Prompts interativos     | Execução deve ser explícita             |
+| Gestão de processos     | Não rastrear PIDs ou status de execução |
+| Integração Transmute    | Reservado para pós-MVP                  |
+| Múltiplos terminais     | WezTerm é suficiente para MVP           |
+
+## Arquitetura
+
+O plugin será implementado como um **app no monorepo Transmute**, em `apps/opencode-transmute/`.
+
+```
+transmute/
+├── apps/
+│   ├── web/                         # App Next.js existente
+│   ├── docs/                        # Documentação existente
+│   └── opencode-transmute/          # Novo app - Plugin OpenCode
+│       ├── src/
+│       │   ├── core/                # Domínio do plugin
+│       │   │   ├── naming.ts        # Geração de nomes de branch
+│       │   │   ├── worktree.ts      # Criação/gestão de worktrees
+│       │   │   ├── session.ts       # Persistência de estado
+│       │   │   └── hooks.ts         # Execução de hooks declarativos
+│       │   │
+│       │   ├── adapters/            # Integrações externas
+│       │   │   ├── terminal/
+│       │   │   │   ├── types.ts     # Interface abstrata
+│       │   │   │   └── wezterm.ts   # Implementação WezTerm
+│       │   │   └── git/
+│       │   │       └── worktree.ts  # Operações Git
+│       │   │
+│       │   ├── tools/               # Tools expostas ao OpenCode
+│       │   │   ├── start-task.ts    # Iniciar sessão isolada
+│       │   │   └── index.ts         # Registry de tools
+│       │   │
+│       │   └── index.ts             # Entry point do plugin
+│       │
+│       ├── package.json
+│       └── tsconfig.json
+│
+├── packages/
+│   ├── schemas/                     # Schemas compartilhados (reutilizável)
+│   └── utils/                       # Utilitários compartilhados
+│
+└── projects/                        # Conteúdo markdown (PRDs + Tasks)
+```
+
+### Benefícios da Localização em `apps/`
+
+1. **Consistência**: Segue o padrão do monorepo (web, docs, agora opencode-transmute)
+2. **Compartilhamento**: Pode importar `@repo/schemas` e `@repo/utils`
+3. **Build Pipeline**: Integrado ao Turborepo existente
+4. **Isolamento**: App independente, não polui outros packages
+
+### Separação de Responsabilidades
+
+1. **Core**: Lógica de domínio pura, sem dependências externas
+2. **Adapters**: Integrações com Git, terminais, etc.
+3. **Tools**: Interface com o OpenCode
+
+## Modelo de Execução
+
+### Princípios
+
+1. **Determinístico**: Apenas comandos definidos em hooks são executados
+2. **Explícito**: Nenhuma ação implícita ou mágica
+3. **Auditável**: Logs claros de todas as operações
+4. **Não-interativo**: Sem prompts durante execução
+
+### Fluxo de `start-task`
+
+```
+1. Receber task ID/nome
+2. Gerar nome de branch (ex: feat/task-123-description)
+3. Verificar se já existe worktree para esta tarefa
+4. Se não existe:
+   a. Criar branch a partir de main
+   b. Criar worktree em ./worktrees/<branch-name>
+   c. Persistir estado em .opencode/transmute.sessions.json
+5. Abrir sessão WezTerm no diretório do worktree
+6. Executar hooks declarados (install, setup, etc.)
+7. Retornar status e path do worktree
+```
+
+### Hooks Declarativos
+
+```typescript
+// opencode.config.ts
+export default {
+  transmute: {
+    hooks: {
+      afterCreate: ["pnpm install", "pnpm dev"],
+    },
+  },
+};
+```
+
+## Persistência de Estado
+
+### O que persistir
+
+```typescript
+interface TransmuteSession {
+  taskId: string;
+  taskName: string;
+  branch: string;
+  worktreePath: string;
+  createdAt: string;
+}
+
+interface TransmuteState {
+  sessions: TransmuteSession[];
+}
+```
+
+### O que NÃO persistir
+
+- Status da tarefa (vem do Transmute)
+- Processos ativos ou PIDs
+- Estado de execução de hooks
+- Configurações de terminal
+
+### Arquivo de Estado
+
+```json
+// .opencode/transmute.sessions.json
+{
+  "sessions": [
+    {
+      "taskId": "task-123",
+      "taskName": "implement-auth",
+      "branch": "feat/task-123-implement-auth",
+      "worktreePath": "./worktrees/feat-task-123-implement-auth",
+      "createdAt": "2026-01-17T10:30:00Z"
+    }
+  ]
+}
+```
+
+## Decisões Técnicas
+
+### D1: WezTerm como terminal principal
+
+**Decisão**: Usar WezTerm como única integração de terminal no MVP.
+
+**Razão**:
+
+- API CLI robusta e bem documentada
+- Suporte a panes e tabs na mesma janela
+- Evita complexidade de abstrações prematuras
+
+**Trade-off**: Usuários de outros terminais precisarão aguardar pós-MVP.
+
+### D2: Git worktrees vs branches simples
+
+**Decisão**: Usar git worktrees para isolamento real.
+
+**Razão**:
+
+- Isolamento completo de arquivos
+- Múltiplas tarefas podem rodar em paralelo
+- Evita conflitos de working directory
+
+**Trade-off**: Usa mais espaço em disco, requer gestão de worktrees.
+
+### D3: Hooks declarativos vs scripts arbitrários
+
+**Decisão**: Apenas hooks declarados em config são executados.
+
+**Razão**:
+
+- Previsibilidade e segurança
+- Fácil auditoria
+- Evita execução de comandos maliciosos
+
+**Trade-off**: Menos flexibilidade para casos edge.
+
+### D4: Persistência mínima
+
+**Decisão**: Persistir apenas dados de mapeamento tarefa→worktree.
+
+**Razão**:
+
+- Simplicidade
+- Estado derivável (pode verificar worktrees existentes)
+- Evita problemas de sincronização
+
+**Trade-off**: Menos informação disponível para decisões automáticas.
+
+## Riscos e Mitigações
+
+| Risco                      | Probabilidade | Impacto | Mitigação                             |
+| -------------------------- | ------------- | ------- | ------------------------------------- |
+| Worktrees órfãos           | Alta          | Médio   | Cleanup periódico pós-MVP             |
+| Conflitos de branch naming | Baixa         | Baixo   | Validação antes de criar              |
+| WezTerm não instalado      | Média         | Alto    | Verificação prévia + erro claro       |
+| Estado corrompido          | Baixa         | Médio   | Estado mínimo + reconstrução possível |
+| Hooks falhando             | Média         | Médio   | Logs claros + continuação opcional    |
+
+## Métricas de Sucesso
+
+### MVP
+
+1. Agente consegue criar worktree isolado via tool
+2. Terminal abre automaticamente no diretório correto
+3. Hooks são executados após criação
+4. Estado é persistido e permite retomada
+5. Múltiplas tarefas podem rodar em worktrees separados
+
+### Pós-MVP
+
+1. Agente consegue buscar tarefas do Transmute
+2. Agente consegue atualizar status no Transmute
+3. Listagem e cleanup de worktrees funcionam
+4. Suporte a múltiplos terminais
+
+## Referências
+
+- [Git Worktrees Documentation](https://git-scm.com/docs/git-worktree)
+- [WezTerm CLI Reference](https://wezfurlong.org/wezterm/cli/general.html)
+- [OpenCode Plugin System](https://opencode.ai/docs)
+- PRD: MCP Server Integration (referência de tools)

--- a/projects/blueprint-ai/opencode-transmute/tasks.md
+++ b/projects/blueprint-ai/opencode-transmute/tasks.md
@@ -1,0 +1,598 @@
+---
+project_id: opencode-transmute
+prd_version: "1.0"
+created_at: "2026-01-17"
+updated_at: "2026-01-17"
+---
+
+# Tasks: OpenCode Transmute Plugin
+
+---
+
+## Task 1: Project Setup
+
+- **id:** oc-trans-001
+- **status:** todo
+- **priority:** critical
+- **description:** Inicializar estrutura do app opencode-transmute no monorepo Transmute.
+
+### Subtasks
+
+#### [ ] Criar estrutura de diretórios
+
+Criar `apps/opencode-transmute` com estrutura:
+
+```
+apps/opencode-transmute/
+├── src/
+│   ├── core/
+│   ├── adapters/
+│   ├── tools/
+│   └── index.ts
+├── package.json
+└── tsconfig.json
+```
+
+#### [ ] Configurar package.json
+
+Definir dependências mínimas:
+
+- typescript
+- zod (validação)
+- `@repo/schemas` (schemas compartilhados)
+- `@repo/utils` (utilitários compartilhados)
+
+#### [ ] Configurar TypeScript
+
+Criar `tsconfig.json` estendendo `@repo/tsconfig`.
+
+#### [ ] Registrar no Turborepo
+
+Atualizar `turbo.json` para incluir o novo app no pipeline de build.
+
+---
+
+## Task 2: Core - Branch Naming
+
+- **id:** oc-trans-002
+- **status:** todo
+- **priority:** high
+- **description:** Implementar lógica de geração de nomes de branch baseada em task ID/nome.
+- **dependencies:** oc-trans-001
+
+### Subtasks
+
+#### [ ] Definir schema de entrada
+
+```typescript
+interface BranchNameInput {
+  taskId: string;
+  taskName?: string;
+  prefix?: string; // default: "feat"
+}
+```
+
+#### [ ] Implementar função de sanitização
+
+Converter strings para formato válido de branch:
+
+- lowercase
+- remover caracteres especiais
+- substituir espaços por hífens
+- limitar tamanho
+
+#### [ ] Implementar generateBranchName
+
+```typescript
+// apps/opencode-transmute/src/core/naming.ts
+function generateBranchName(input: BranchNameInput): string;
+// Ex: "feat/task-123-implement-auth"
+```
+
+#### [ ] Adicionar testes unitários
+
+Cobrir casos:
+
+- Task ID simples
+- Task com nome longo
+- Caracteres especiais no nome
+- Prefixos customizados
+
+---
+
+## Task 3: Core - Git Worktree Management
+
+- **id:** oc-trans-003
+- **status:** todo
+- **priority:** high
+- **description:** Implementar criação e gestão de git worktrees.
+- **dependencies:** oc-trans-001
+
+### Subtasks
+
+#### [ ] Definir interface de worktree
+
+```typescript
+interface Worktree {
+  path: string;
+  branch: string;
+  isMain: boolean;
+}
+
+interface CreateWorktreeOptions {
+  branch: string;
+  baseBranch?: string; // default: "main"
+  targetDir?: string; // default: "./worktrees/<branch>"
+}
+```
+
+#### [ ] Implementar listWorktrees
+
+Executar `git worktree list --porcelain` e parsear output.
+
+#### [ ] Implementar createWorktree
+
+Executar `git worktree add -b <branch> <path> <base>`.
+
+- Verificar se branch já existe
+- Criar diretório worktrees se necessário
+
+#### [ ] Implementar worktreeExists
+
+Verificar se já existe worktree para uma branch específica.
+
+#### [ ] Tratamento de erros
+
+- Branch já existe
+- Diretório já existe
+- Git não inicializado
+- Base branch não existe
+
+---
+
+## Task 4: Core - Session Persistence
+
+- **id:** oc-trans-004
+- **status:** todo
+- **priority:** high
+- **description:** Implementar persistência mínima de estado de sessões.
+- **dependencies:** oc-trans-001
+
+### Subtasks
+
+#### [ ] Definir schema de estado
+
+```typescript
+const sessionSchema = z.object({
+  taskId: z.string(),
+  taskName: z.string(),
+  branch: z.string(),
+  worktreePath: z.string(),
+  createdAt: z.string().datetime(),
+});
+
+const stateSchema = z.object({
+  sessions: z.array(sessionSchema),
+});
+```
+
+#### [ ] Implementar loadState
+
+Ler `.opencode/transmute.sessions.json`.
+Retornar estado vazio se arquivo não existe.
+Validar com Zod.
+
+#### [ ] Implementar saveState
+
+Escrever estado validado no arquivo.
+Criar diretório `.opencode` se necessário.
+
+#### [ ] Implementar addSession / removeSession
+
+Helpers para manipular lista de sessões.
+
+#### [ ] Implementar findSessionByTask
+
+Buscar sessão existente por taskId.
+
+---
+
+## Task 5: Adapter - WezTerm Integration
+
+- **id:** oc-trans-005
+- **status:** todo
+- **priority:** high
+- **description:** Implementar integração com WezTerm para abrir sessões de terminal.
+- **dependencies:** oc-trans-001
+
+### Subtasks
+
+#### [ ] Definir interface abstrata de terminal
+
+```typescript
+// apps/opencode-transmute/src/adapters/terminal/types.ts
+interface TerminalAdapter {
+  isAvailable(): Promise<boolean>;
+  openSession(options: OpenSessionOptions): Promise<void>;
+}
+
+interface OpenSessionOptions {
+  cwd: string;
+  commands?: string[];
+  title?: string;
+}
+```
+
+#### [ ] Verificar disponibilidade do WezTerm
+
+Checar se `wezterm` está no PATH.
+
+#### [ ] Implementar openSession para WezTerm
+
+Usar `wezterm cli spawn --cwd <path>` para abrir nova pane/tab.
+Opcionalmente executar comandos iniciais.
+
+#### [ ] Tratamento de erros
+
+- WezTerm não instalado
+- Falha ao abrir sessão
+- Path inválido
+
+---
+
+## Task 6: Core - Hooks System
+
+- **id:** oc-trans-006
+- **status:** todo
+- **priority:** medium
+- **description:** Implementar sistema de hooks declarativos para execução pós-setup.
+- **dependencies:** oc-trans-001
+
+### Subtasks
+
+#### [ ] Definir schema de configuração de hooks
+
+```typescript
+const hooksConfigSchema = z.object({
+  afterCreate: z.array(z.string()).optional(),
+  beforeDestroy: z.array(z.string()).optional(),
+});
+```
+
+#### [ ] Implementar executeHooks
+
+Executar array de comandos sequencialmente.
+Capturar stdout/stderr.
+Continuar ou parar em caso de erro (configurável).
+
+#### [ ] Implementar logging de hooks
+
+Mostrar output de cada comando executado.
+Indicar sucesso/falha claramente.
+
+---
+
+## Task 7: Tool - start-task
+
+- **id:** oc-trans-007
+- **status:** todo
+- **priority:** critical
+- **description:** Implementar a tool principal que orquestra criação de ambiente isolado.
+- **dependencies:** oc-trans-002, oc-trans-003, oc-trans-004, oc-trans-005, oc-trans-006
+
+### Subtasks
+
+#### [ ] Definir schema de input da tool
+
+```typescript
+const startTaskInputSchema = z.object({
+  taskId: z.string(),
+  taskName: z.string().optional(),
+  baseBranch: z.string().optional(),
+});
+```
+
+#### [ ] Implementar fluxo completo
+
+1. Verificar se já existe sessão para taskId
+2. Se existe, retornar worktree existente
+3. Gerar nome de branch
+4. Criar worktree
+5. Persistir sessão
+6. Abrir terminal no worktree
+7. Executar hooks afterCreate
+8. Retornar resultado
+
+#### [ ] Definir schema de output
+
+```typescript
+const startTaskOutputSchema = z.object({
+  status: z.enum(["created", "existing"]),
+  branch: z.string(),
+  worktreePath: z.string(),
+  taskId: z.string(),
+});
+```
+
+#### [ ] Registrar como tool do OpenCode
+
+Expor tool com nome, descrição e schemas adequados.
+
+---
+
+## Task 8: Configuration
+
+- **id:** oc-trans-008
+- **status:** todo
+- **priority:** medium
+- **description:** Implementar sistema de configuração do plugin.
+- **dependencies:** oc-trans-001
+
+### Subtasks
+
+#### [ ] Definir schema de configuração
+
+```typescript
+const configSchema = z.object({
+  worktreesDir: z.string().default("./worktrees"),
+  branchPrefix: z.string().default("feat"),
+  hooks: hooksConfigSchema.optional(),
+  terminal: z.enum(["wezterm"]).default("wezterm"),
+});
+```
+
+#### [ ] Implementar loadConfig
+
+Buscar configuração em:
+
+1. `opencode.config.ts` (seção transmute)
+2. `.opencode/transmute.config.json`
+3. Defaults
+
+#### [ ] Validar configuração
+
+Usar Zod para validação e merge com defaults.
+
+---
+
+## Task 9: Integration Testing
+
+- **id:** oc-trans-009
+- **status:** todo
+- **priority:** medium
+- **description:** Criar testes de integração para o fluxo completo.
+- **dependencies:** oc-trans-007
+
+### Subtasks
+
+#### [ ] Setup de ambiente de teste
+
+Criar repositório git temporário para testes.
+Configurar mocks para terminal adapter.
+
+#### [ ] Testar fluxo de criação completo
+
+Verificar que worktree é criado corretamente.
+Verificar que estado é persistido.
+Verificar que branch existe.
+
+#### [ ] Testar retomada de sessão
+
+Criar sessão, verificar que segunda chamada retorna existente.
+
+#### [ ] Testar cleanup
+
+Verificar que worktree pode ser removido corretamente.
+
+---
+
+## Task 10: Documentation
+
+- **id:** oc-trans-010
+- **status:** todo
+- **priority:** low
+- **description:** Documentar uso e configuração do plugin.
+- **dependencies:** oc-trans-007, oc-trans-008
+
+### Subtasks
+
+#### [ ] README do app
+
+- Overview do plugin
+- Como funciona no contexto do monorepo Transmute
+- Configuração básica
+- Exemplo de uso
+
+#### [ ] Documentação de API
+
+- Tools disponíveis
+- Schemas de input/output
+- Configurações suportadas
+
+#### [ ] Troubleshooting
+
+- WezTerm não encontrado
+- Erros comuns de Git
+- Como limpar worktrees manualmente
+
+---
+
+# Backlog Pós-MVP
+
+As tarefas abaixo estão planejadas para iterações futuras, após validação do MVP.
+
+---
+
+## Task 11: Tool - list-sessions
+
+- **id:** oc-trans-011
+- **status:** todo
+- **priority:** low
+- **description:** Implementar tool para listar sessões/worktrees ativos.
+- **dependencies:** oc-trans-007
+- **comment:** Pós-MVP - Gestão de sessões
+
+### Subtasks
+
+#### [ ] Implementar listagem de sessões
+
+Combinar dados persistidos com worktrees existentes.
+
+#### [ ] Detectar sessões órfãs
+
+Worktrees sem sessão registrada e vice-versa.
+
+---
+
+## Task 12: Tool - cleanup-sessions
+
+- **id:** oc-trans-012
+- **status:** todo
+- **priority:** low
+- **description:** Implementar tool para limpar worktrees antigos ou órfãos.
+- **dependencies:** oc-trans-011
+- **comment:** Pós-MVP - Gestão de sessões
+
+### Subtasks
+
+#### [ ] Implementar remoção de worktree
+
+Executar `git worktree remove` e atualizar estado.
+
+#### [ ] Implementar cleanup por idade
+
+Remover worktrees mais antigos que X dias.
+
+#### [ ] Implementar cleanup de órfãos
+
+Remover worktrees sem sessão correspondente.
+
+---
+
+## Task 13: Tool - transmute-list-tasks
+
+- **id:** oc-trans-013
+- **status:** todo
+- **priority:** medium
+- **description:** Implementar tool para buscar tarefas do Transmute.
+- **dependencies:** oc-trans-007
+- **comment:** Pós-MVP - Integração Transmute
+
+### Subtasks
+
+#### [ ] Integrar com markdown parser do Transmute
+
+Importar e reutilizar funções de `apps/web/src/lib/markdown.ts`:
+
+- `getAllTasksWithProject`
+- `getProject`
+
+Considerar extrair para `packages/markdown` se necessário.
+
+#### [ ] Filtrar por status
+
+Permitir filtrar por todo, in_progress, etc.
+
+#### [ ] Filtrar por workspace/projeto
+
+Permitir escopo específico.
+
+---
+
+## Task 14: Tool - transmute-update-status
+
+- **id:** oc-trans-014
+- **status:** todo
+- **priority:** medium
+- **description:** Implementar tool para atualizar status de tarefas no Transmute.
+- **dependencies:** oc-trans-013
+- **comment:** Pós-MVP - Integração Transmute
+
+### Subtasks
+
+#### [ ] Integrar com API de update
+
+Reutilizar lógica do endpoint `PATCH /api/tasks/[taskId]` de `apps/web`.
+Considerar extrair para função compartilhada se necessário.
+
+#### [ ] Atualizar status de tarefa
+
+Marcar como in_progress, done, blocked.
+
+#### [ ] Adicionar comentários
+
+Permitir adicionar notas à tarefa.
+
+---
+
+## Task 15: Adapter - tmux Integration
+
+- **id:** oc-trans-015
+- **status:** todo
+- **priority:** low
+- **description:** Implementar adapter de terminal para tmux.
+- **dependencies:** oc-trans-005
+- **comment:** Pós-MVP - Extensibilidade
+
+### Subtasks
+
+#### [ ] Implementar TerminalAdapter para tmux
+
+Usar `tmux new-window` ou `tmux split-window`.
+
+#### [ ] Configuração de sessão/janela
+
+Permitir especificar sessão tmux alvo.
+
+---
+
+## Task 16: New Window Spawn Option
+
+- **id:** oc-trans-016
+- **status:** todo
+- **priority:** low
+- **description:** Adicionar opção para abrir worktree em nova janela de terminal.
+- **dependencies:** oc-trans-005
+- **comment:** Pós-MVP - UX
+
+### Subtasks
+
+#### [ ] Adicionar opção spawnNewWindow
+
+```typescript
+interface OpenSessionOptions {
+  // ...
+  spawnNewWindow?: boolean;
+}
+```
+
+#### [ ] Implementar para WezTerm
+
+Usar `wezterm start` ao invés de `wezterm cli spawn`.
+
+---
+
+# Priorização e Justificativas
+
+## Ordem de Execução MVP
+
+| Ordem | Task         | Justificativa                                   |
+| ----- | ------------ | ----------------------------------------------- |
+| 1     | oc-trans-001 | Setup é pré-requisito para tudo                 |
+| 2     | oc-trans-002 | Branch naming é simples e independente          |
+| 3     | oc-trans-003 | Worktree é a funcionalidade central             |
+| 4     | oc-trans-004 | Persistência é simples mas necessária           |
+| 5     | oc-trans-005 | Terminal é a interface do usuário               |
+| 6     | oc-trans-006 | Hooks agregam valor mas não bloqueiam           |
+| 7     | oc-trans-008 | Config antes da tool para definir comportamento |
+| 8     | oc-trans-007 | Tool principal integra tudo                     |
+| 9     | oc-trans-009 | Testes validam a implementação                  |
+| 10    | oc-trans-010 | Docs podem ser feitas em paralelo               |
+
+## Critérios de Aceite Gerais
+
+1. **Code Review**: Todo código passa por lint e type-check
+2. **Testes**: Funcionalidades core têm testes unitários
+3. **Logs**: Operações importantes são logadas
+4. **Erros**: Mensagens de erro são claras e acionáveis
+5. **Configurável**: Comportamentos têm defaults sensatos mas são customizáveis


### PR DESCRIPTION
## Summary

- Add PRD and tasks for **opencode-transmute** plugin in `apps/opencode-transmute`
- Fix React hydration mismatch in TaskList component

## OpenCode Transmute Plugin

A plugin for OpenCode that creates **isolated development environments per task** using git worktrees:

- **Branch naming**: Auto-generate branch names from task IDs
- **Git worktrees**: Create isolated worktrees for parallel task work
- **Terminal integration**: Open WezTerm sessions in worktree directories
- **Session persistence**: Track task ↔ branch ↔ worktree mappings
- **Declarative hooks**: Run setup commands after worktree creation

### MVP Tasks (10 tasks)
1. Project Setup
2. Core - Branch Naming
3. Core - Git Worktree Management
4. Core - Session Persistence
5. Adapter - WezTerm Integration
6. Core - Hooks System
7. Tool - start-task
8. Configuration
9. Integration Testing
10. Documentation

### Post-MVP (6 tasks)
- Session listing and cleanup
- Transmute integration (list tasks, update status)
- tmux adapter
- New window spawn option

## Hydration Fix

Fixed `DndContext` hydration mismatch by adding a stable `id` prop. The issue was that `@dnd-kit` generates different `aria-describedby` IDs on server vs client.

```tsx
<DndContext
  id="task-list-dnd"  // Added stable ID
  sensors={sensors}
  ...
>
```

## Links

- PRD: `projects/blueprint-ai/opencode-transmute/prd.md`
- Tasks: `projects/blueprint-ai/opencode-transmute/tasks.md`