### PR TITLE
docs: add opencode-transmute plugin documentation

### DIFF
--- a/apps/docs/content/docs/plugins/index.mdx
+++ b/apps/docs/content/docs/plugins/index.mdx
@@ -1,0 +1,48 @@
+---
+title: Plugins
+description: Extend Transmute with powerful plugins and integrations
+---
+
+# Plugins
+
+Transmute can be extended with plugins that integrate with AI coding assistants and development tools.
+
+## Available Plugins
+
+### OpenCode Transmute
+
+The **opencode-transmute** plugin integrates Transmute with [OpenCode](https://opencode.ai), enabling AI agents to create isolated development environments for each task using git worktrees.
+
+[Learn more about OpenCode Transmute](/docs/plugins/opencode-transmute)
+
+## Plugin Architecture
+
+Plugins in Transmute follow a simple pattern:
+
+1. **Tools** - Functions that AI agents can call to perform actions
+2. **Configuration** - User-customizable settings loaded from config files
+3. **Adapters** - Integrations with external tools (terminals, IDEs, etc.)
+
+## Creating Plugins
+
+Plugins are npm packages that export a `Plugin` function compatible with the host platform (e.g., OpenCode).
+
+```typescript
+import type { Plugin } from "@opencode-ai/plugin";
+
+export const MyPlugin: Plugin = async (ctx) => {
+  return {
+    tool: {
+      "my-tool": tool({
+        description: "My custom tool",
+        args: {
+          /* ... */
+        },
+        execute: async (args) => {
+          /* ... */
+        },
+      }),
+    },
+  };
+};
+```

--- a/apps/docs/content/docs/plugins/opencode-transmute/api.mdx
+++ b/apps/docs/content/docs/plugins/opencode-transmute/api.mdx
@@ -1,0 +1,264 @@
+---
+title: API Reference
+description: Tools, schemas, and functions exported by opencode-transmute
+---
+
+# API Reference
+
+This page documents the tools, schemas, and functions exported by the `opencode-transmute` package.
+
+## Tools
+
+### `start-task`
+
+Creates an isolated git worktree for a task. If a session already exists, it resumes the existing worktree.
+
+#### Input Schema
+
+| Parameter     | Type     | Required | Description                                               |
+| ------------- | -------- | -------- | --------------------------------------------------------- |
+| `taskId`      | `string` | Yes      | Unique task identifier                                    |
+| `title`       | `string` | Yes      | Task title for branch name generation                     |
+| `description` | `string` | No       | Task description for better AI inference                  |
+| `priority`    | `string` | No       | Task priority (low, medium, high, critical)               |
+| `type`        | `string` | No       | Branch type hint (feat, fix, refactor, docs, chore, test) |
+| `baseBranch`  | `string` | No       | Base branch to create from (default: main)                |
+
+#### Output Schema
+
+| Field               | Type                      | Description                        |
+| ------------------- | ------------------------- | ---------------------------------- |
+| `status`            | `"created" \| "existing"` | Whether a new worktree was created |
+| `branch`            | `string`                  | The git branch name                |
+| `worktreePath`      | `string`                  | Absolute path to the worktree      |
+| `taskId`            | `string`                  | The task ID                        |
+| `taskName`          | `string`                  | The task title                     |
+| `opencodeSessionId` | `string`                  | OpenCode session ID for resumption |
+
+#### Example
+
+```typescript
+// Agent calls the tool
+const result = await tools["start-task"]({
+  taskId: "task-123",
+  title: "Implement user authentication",
+  description: "Add OAuth2 login with Google",
+  type: "feat",
+});
+
+// Result
+{
+  status: "created",
+  branch: "feat/implement-user-authentication",
+  worktreePath: "/repo/worktrees/feat-implement-user-authentication",
+  taskId: "task-123",
+  taskName: "Implement user authentication",
+  opencodeSessionId: "ses_abc123"
+}
+```
+
+## Exported Functions
+
+### Branch Naming
+
+#### `generateBranchName(context, client?, sessionId?)`
+
+Generates an AI-powered branch name based on task context.
+
+```typescript
+import { generateBranchName } from "opencode-transmute";
+
+const result = await generateBranchName({
+  id: "task-123",
+  title: "Fix memory leak",
+  description: "Memory leak in the parser module",
+});
+
+// { branch: "fix/memory-leak-parser", type: "fix", slug: "memory-leak-parser" }
+```
+
+#### `sanitizeBranchName(name)`
+
+Sanitizes a string for use as a git branch name.
+
+```typescript
+import { sanitizeBranchName } from "opencode-transmute";
+
+sanitizeBranchName("Fix: Memory Leak!"); // "fix-memory-leak"
+```
+
+### Worktree Management
+
+#### `createWorktree(options)`
+
+Creates a new git worktree.
+
+```typescript
+import { createWorktree } from "opencode-transmute";
+
+const worktree = await createWorktree({
+  branch: "feat/new-feature",
+  baseBranch: "main",
+  cwd: "/path/to/repo",
+});
+
+// { path: "/repo/worktrees/feat-new-feature", branch: "feat/new-feature", isMain: false }
+```
+
+#### `listWorktrees(cwd?)`
+
+Lists all worktrees in the repository.
+
+```typescript
+import { listWorktrees } from "opencode-transmute";
+
+const worktrees = await listWorktrees();
+// [
+//   { path: "/repo", branch: "main", isMain: true },
+//   { path: "/repo/worktrees/feat-auth", branch: "feat/auth", isMain: false }
+// ]
+```
+
+#### `removeWorktree(path, force?, cwd?)`
+
+Removes a worktree.
+
+```typescript
+import { removeWorktree } from "opencode-transmute";
+
+await removeWorktree("/repo/worktrees/feat-auth");
+```
+
+### Session Management
+
+#### `findSessionByTask(basePath, taskId)`
+
+Finds an existing session by task ID.
+
+```typescript
+import { findSessionByTask } from "opencode-transmute";
+
+const session = await findSessionByTask("/repo", "task-123");
+// { taskId: "task-123", branch: "feat/...", worktreePath: "...", ... }
+```
+
+#### `addSession(basePath, session)`
+
+Persists a new session.
+
+```typescript
+import { addSession } from "opencode-transmute";
+
+await addSession("/repo", {
+  taskId: "task-123",
+  taskName: "My Task",
+  branch: "feat/my-task",
+  worktreePath: "/repo/worktrees/feat-my-task",
+  createdAt: new Date().toISOString(),
+  opencodeSessionId: "ses_abc",
+});
+```
+
+#### `removeSession(basePath, taskId)`
+
+Removes a session.
+
+```typescript
+import { removeSession } from "opencode-transmute";
+
+await removeSession("/repo", "task-123");
+```
+
+### Configuration
+
+#### `loadConfig(basePath)`
+
+Loads configuration from all sources with precedence.
+
+```typescript
+import { loadConfig } from "opencode-transmute";
+
+const { config, source, configPath } = await loadConfig("/repo");
+// config: { worktreesDir: "./worktrees", terminal: "wezterm", ... }
+// source: "json" | "opencode.config.ts" | "default"
+// configPath: "/repo/.opencode/transmute.config.json" (if loaded from file)
+```
+
+#### `validateConfig(config)`
+
+Validates a configuration object.
+
+```typescript
+import { validateConfig } from "opencode-transmute";
+
+const result = validateConfig({ terminal: "wezterm" });
+if (result.success) {
+  console.log(result.data); // Full config with defaults
+} else {
+  console.error(result.error); // Zod validation error
+}
+```
+
+### Hooks
+
+#### `executeHooks(commands, options)`
+
+Executes an array of shell commands.
+
+```typescript
+import { executeHooks } from "opencode-transmute";
+
+const results = await executeHooks(["pnpm install", "pnpm build"], {
+  cwd: "/path/to/worktree",
+  stopOnError: true,
+});
+
+// [
+//   { command: "pnpm install", success: true, duration: 5000, ... },
+//   { command: "pnpm build", success: true, duration: 3000, ... }
+// ]
+```
+
+## Zod Schemas
+
+All schemas are exported for validation and type inference:
+
+```typescript
+import {
+  configSchema,
+  sessionSchema,
+  stateSchema,
+  startTaskInputSchema,
+  startTaskOutputSchema,
+  taskContextSchema,
+  branchNameResultSchema,
+  hooksConfigSchema,
+} from "opencode-transmute";
+
+// Use for validation
+const config = configSchema.parse(userInput);
+
+// Use for type inference
+type Config = z.infer<typeof configSchema>;
+```
+
+## Error Classes
+
+```typescript
+import {
+  BranchAlreadyExistsError,
+  DirectoryAlreadyExistsError,
+  BaseBranchNotFoundError,
+  GitNotInitializedError,
+  TerminalNotAvailableError,
+  TerminalSpawnError,
+} from "opencode-transmute";
+
+try {
+  await createWorktree({ branch: "feat/existing" });
+} catch (error) {
+  if (error instanceof BranchAlreadyExistsError) {
+    console.log(`Branch ${error.branch} already has a worktree`);
+  }
+}
+```

--- a/apps/docs/content/docs/plugins/opencode-transmute/configuration.mdx
+++ b/apps/docs/content/docs/plugins/opencode-transmute/configuration.mdx
@@ -1,0 +1,151 @@
+---
+title: Configuration
+description: Customize opencode-transmute behavior
+---
+
+# Configuration
+
+The plugin supports configuration through multiple sources, loaded in order of precedence.
+
+## Configuration Sources
+
+1. **`opencode.config.ts`** (highest priority)
+2. **`.opencode/transmute.config.json`**
+3. **`transmute.config.json`**
+4. **Default values** (fallback)
+
+## Configuration Options
+
+| Option                | Type      | Default         | Description                           |
+| --------------------- | --------- | --------------- | ------------------------------------- |
+| `worktreesDir`        | `string`  | `"./worktrees"` | Directory for git worktrees           |
+| `defaultBranchType`   | `string`  | `"feat"`        | Default branch type prefix            |
+| `maxBranchSlugLength` | `number`  | `40`            | Maximum length for branch slug        |
+| `terminal`            | `string`  | `"wezterm"`     | Terminal adapter to use               |
+| `autoOpenTerminal`    | `boolean` | `true`          | Open terminal after creating worktree |
+| `autoRunHooks`        | `boolean` | `true`          | Run hooks after creating worktree     |
+| `defaultBaseBranch`   | `string`  | `"main"`        | Base branch for new worktrees         |
+| `useAiBranchNaming`   | `boolean` | `true`          | Use AI for branch name generation     |
+| `hooks`               | `object`  | See below       | Lifecycle hooks                       |
+
+## Configuration Examples
+
+### Using `opencode.config.ts`
+
+```typescript
+export default {
+  transmute: {
+    worktreesDir: "./wt",
+    terminal: "wezterm",
+    defaultBaseBranch: "develop",
+    hooks: {
+      afterCreate: ["pnpm install", "pnpm build"],
+    },
+  },
+};
+```
+
+### Using `.opencode/transmute.config.json`
+
+```json
+{
+  "worktreesDir": "./worktrees",
+  "terminal": "tmux",
+  "autoOpenTerminal": false,
+  "defaultBaseBranch": "main",
+  "useAiBranchNaming": true,
+  "hooks": {
+    "afterCreate": ["npm ci"],
+    "beforeDestroy": ["npm run clean"]
+  }
+}
+```
+
+## Terminal Options
+
+| Value       | Description                    |
+| ----------- | ------------------------------ |
+| `"wezterm"` | WezTerm terminal (default)     |
+| `"tmux"`    | tmux multiplexer (coming soon) |
+| `"kitty"`   | Kitty terminal (coming soon)   |
+| `"none"`    | Disable terminal integration   |
+
+## Branch Type Options
+
+The `defaultBranchType` option accepts:
+
+| Value        | Use Case              |
+| ------------ | --------------------- |
+| `"feat"`     | New features          |
+| `"fix"`      | Bug fixes             |
+| `"refactor"` | Code refactoring      |
+| `"docs"`     | Documentation changes |
+| `"chore"`    | Maintenance tasks     |
+| `"test"`     | Test additions        |
+
+## Hooks Configuration
+
+Hooks are shell commands executed at specific lifecycle points.
+
+### `afterCreate`
+
+Commands run after a worktree is created:
+
+```json
+{
+  "hooks": {
+    "afterCreate": ["pnpm install", "pnpm run setup", "cp .env.example .env"]
+  }
+}
+```
+
+### `beforeDestroy`
+
+Commands run before a worktree is removed:
+
+```json
+{
+  "hooks": {
+    "beforeDestroy": ["pnpm run cleanup"]
+  }
+}
+```
+
+### Default Hooks
+
+If no hooks are configured, the default is:
+
+```json
+{
+  "afterCreate": ["[ -f package.json ] && pnpm install || true"],
+  "beforeDestroy": []
+}
+```
+
+## Environment Variables
+
+Hooks have access to these environment variables:
+
+| Variable             | Description          |
+| -------------------- | -------------------- |
+| `TRANSMUTE_TASK_ID`  | The task ID          |
+| `TRANSMUTE_BRANCH`   | The branch name      |
+| `TRANSMUTE_WORKTREE` | Path to the worktree |
+
+## Programmatic Configuration
+
+You can also configure the plugin programmatically:
+
+```typescript
+import { TransmutePlugin } from "opencode-transmute";
+import { loadConfig, mergeConfig } from "opencode-transmute";
+
+// Load and modify config
+const { config } = await loadConfig("/path/to/repo");
+
+const customConfig = mergeConfig({
+  ...config,
+  terminal: "none",
+  autoOpenTerminal: false,
+});
+```

--- a/apps/docs/content/docs/plugins/opencode-transmute/index.mdx
+++ b/apps/docs/content/docs/plugins/opencode-transmute/index.mdx
@@ -1,0 +1,128 @@
+---
+title: OpenCode Transmute
+description: AI-powered task isolation with git worktrees
+---
+
+# OpenCode Transmute
+
+**opencode-transmute** is a plugin for [OpenCode](https://opencode.ai) that creates isolated development environments for each task using git worktrees.
+
+## Why Use This Plugin?
+
+When working on multiple tasks, code changes can interfere with each other. This plugin solves that by:
+
+- **Isolating each task** in its own git worktree
+- **Generating intelligent branch names** using AI
+- **Persisting sessions** so you can resume work seamlessly
+- **Opening terminals** in the correct directory automatically
+
+## Quick Start
+
+### 1. Install the Plugin
+
+```bash
+pnpm add opencode-transmute
+```
+
+### 2. Configure OpenCode
+
+Add to your `opencode.config.ts`:
+
+```typescript
+import { TransmutePlugin } from "opencode-transmute";
+
+export default {
+  plugins: [TransmutePlugin],
+};
+```
+
+### 3. Use the Tool
+
+The plugin adds a `start-task` tool that AI agents can use:
+
+```
+Agent: I'll create an isolated environment for this task.
+[Calls start-task with taskId="task-123", title="Add OAuth login"]
+
+Result: Created worktree at ./worktrees/feat-add-oauth-login
+```
+
+## How It Works
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  1. Agent calls start-task                                  │
+│     taskId: "task-123"                                      │
+│     title: "Add OAuth login"                                │
+├─────────────────────────────────────────────────────────────┤
+│  2. AI generates branch name                                │
+│     → "feat/add-oauth-login"                                │
+├─────────────────────────────────────────────────────────────┤
+│  3. Git worktree created                                    │
+│     → ./worktrees/feat-add-oauth-login                      │
+├─────────────────────────────────────────────────────────────┤
+│  4. Session persisted                                       │
+│     → .opencode/transmute.sessions.json                     │
+├─────────────────────────────────────────────────────────────┤
+│  5. Hooks executed (optional)                               │
+│     → pnpm install                                          │
+├─────────────────────────────────────────────────────────────┤
+│  6. Terminal opened                                         │
+│     → WezTerm spawns in worktree directory                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Features
+
+### AI Branch Naming
+
+The plugin uses AI to generate meaningful branch names based on task context:
+
+| Task Title                  | Generated Branch              |
+| --------------------------- | ----------------------------- |
+| "Add Google OAuth login"    | `feat/add-google-oauth-login` |
+| "Fix memory leak in parser" | `fix/memory-leak-parser`      |
+| "Refactor database layer"   | `refactor/database-layer`     |
+
+If AI is unavailable, it falls back to deterministic naming:
+
+```
+feat/task-123-add-google-oauth
+```
+
+### Session Persistence
+
+Sessions are saved to `.opencode/transmute.sessions.json`:
+
+```json
+{
+  "sessions": [
+    {
+      "taskId": "task-123",
+      "taskName": "Add OAuth login",
+      "branch": "feat/add-oauth-login",
+      "worktreePath": "/repo/worktrees/feat-add-oauth-login",
+      "createdAt": "2026-01-18T10:30:00Z",
+      "opencodeSessionId": "ses_abc123"
+    }
+  ]
+}
+```
+
+When you call `start-task` for an existing task, it resumes the session instead of creating a new one.
+
+### Terminal Integration
+
+Currently supports **WezTerm** with planned support for tmux and kitty.
+
+The terminal opens with:
+
+- Working directory set to the worktree
+- OpenCode session resumed automatically
+- Custom title showing task name and branch
+
+## Next Steps
+
+- [Configuration](/docs/plugins/opencode-transmute/configuration) - Customize the plugin behavior
+- [API Reference](/docs/plugins/opencode-transmute/api) - Tools and schemas
+- [Troubleshooting](/docs/plugins/opencode-transmute/troubleshooting) - Common issues and solutions

--- a/apps/docs/content/docs/plugins/opencode-transmute/troubleshooting.mdx
+++ b/apps/docs/content/docs/plugins/opencode-transmute/troubleshooting.mdx
@@ -1,0 +1,317 @@
+---
+title: Troubleshooting
+description: Common issues and solutions for opencode-transmute
+---
+
+# Troubleshooting
+
+This guide covers common issues you might encounter when using opencode-transmute.
+
+## Terminal Issues
+
+### WezTerm Not Found
+
+**Error:** `TerminalNotAvailableError: Terminal 'wezterm' is not available`
+
+**Cause:** WezTerm is not installed or not in your PATH.
+
+**Solutions:**
+
+1. **Install WezTerm:**
+
+   ```bash
+   # macOS
+   brew install wezterm
+
+   # Linux (Debian/Ubuntu)
+   curl -fsSL https://apt.fury.io/wez/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/wezterm-fury.gpg
+   echo 'deb [signed-by=/usr/share/keyrings/wezterm-fury.gpg] https://apt.fury.io/wez/ * *' | sudo tee /etc/apt/sources.list.d/wezterm.list
+   sudo apt update && sudo apt install wezterm
+   ```
+
+2. **Verify installation:**
+
+   ```bash
+   wezterm --version
+   ```
+
+3. **Or disable terminal integration:**
+   ```json
+   {
+     "terminal": "none",
+     "autoOpenTerminal": false
+   }
+   ```
+
+### Terminal Opens But Commands Fail
+
+**Cause:** The terminal opens but OpenCode session resume fails.
+
+**Solutions:**
+
+1. Check that OpenCode is installed and in PATH:
+
+   ```bash
+   opencode --version
+   ```
+
+2. Verify the session ID exists:
+   ```bash
+   cat .opencode/transmute.sessions.json
+   ```
+
+## Git Worktree Issues
+
+### Branch Already Exists
+
+**Error:** `BranchAlreadyExistsError: Branch 'feat/my-feature' already has a worktree`
+
+**Cause:** You're trying to create a worktree for a branch that already exists.
+
+**Solutions:**
+
+1. **Check existing worktrees:**
+
+   ```bash
+   git worktree list
+   ```
+
+2. **Remove the existing worktree:**
+
+   ```bash
+   git worktree remove ./worktrees/feat-my-feature
+   ```
+
+3. **Or use a different branch name** by providing a `type` hint.
+
+### Directory Already Exists
+
+**Error:** `DirectoryAlreadyExistsError: Directory './worktrees/feat-my-feature' already exists`
+
+**Cause:** The target directory exists but isn't a valid worktree.
+
+**Solutions:**
+
+1. **Remove the directory:**
+
+   ```bash
+   rm -rf ./worktrees/feat-my-feature
+   ```
+
+2. **Prune stale worktrees:**
+   ```bash
+   git worktree prune
+   ```
+
+### Base Branch Not Found
+
+**Error:** `BaseBranchNotFoundError: Base branch 'develop' does not exist`
+
+**Cause:** The configured base branch doesn't exist locally.
+
+**Solutions:**
+
+1. **Fetch the branch:**
+
+   ```bash
+   git fetch origin develop
+   git checkout -b develop origin/develop
+   ```
+
+2. **Or use a different base branch:**
+   ```json
+   {
+     "defaultBaseBranch": "main"
+   }
+   ```
+
+### Git Not Initialized
+
+**Error:** `GitNotInitializedError: Not a git repository`
+
+**Cause:** You're trying to use the plugin outside a git repository.
+
+**Solution:**
+
+Initialize a git repository:
+
+```bash
+git init
+git add .
+git commit -m "Initial commit"
+```
+
+## Session Issues
+
+### Session Not Found
+
+**Symptom:** Calling `start-task` for an existing task creates a new worktree instead of resuming.
+
+**Cause:** The session file was deleted or corrupted.
+
+**Solutions:**
+
+1. **Check the session file:**
+
+   ```bash
+   cat .opencode/transmute.sessions.json
+   ```
+
+2. **If corrupted, reset:**
+   ```bash
+   echo '{"sessions":[]}' > .opencode/transmute.sessions.json
+   ```
+
+### Orphaned Worktrees
+
+**Symptom:** Worktrees exist but no session records.
+
+**Solutions:**
+
+1. **List all worktrees:**
+
+   ```bash
+   git worktree list
+   ```
+
+2. **Remove orphaned worktrees manually:**
+
+   ```bash
+   git worktree remove ./worktrees/feat-old-feature --force
+   ```
+
+3. **Prune all stale worktrees:**
+   ```bash
+   git worktree prune
+   ```
+
+## Hook Issues
+
+### Hooks Not Running
+
+**Symptom:** `afterCreate` hooks don't execute.
+
+**Cause:** `autoRunHooks` is set to `false` or hooks array is empty.
+
+**Solutions:**
+
+1. **Check configuration:**
+
+   ```bash
+   cat .opencode/transmute.config.json
+   ```
+
+2. **Ensure hooks are enabled:**
+   ```json
+   {
+     "autoRunHooks": true,
+     "hooks": {
+       "afterCreate": ["pnpm install"]
+     }
+   }
+   ```
+
+### Hook Command Fails
+
+**Symptom:** Hook runs but fails with exit code.
+
+**Solutions:**
+
+1. **Check the command works manually:**
+
+   ```bash
+   cd ./worktrees/feat-my-feature
+   pnpm install
+   ```
+
+2. **Make commands fault-tolerant:**
+
+   ```json
+   {
+     "hooks": {
+       "afterCreate": ["pnpm install || true"]
+     }
+   }
+   ```
+
+3. **Check hook execution results** - they're logged to console.
+
+## Configuration Issues
+
+### Config Not Loading
+
+**Symptom:** Custom configuration is ignored.
+
+**Cause:** Config file is in wrong location or has syntax errors.
+
+**Solutions:**
+
+1. **Check file location** (in order of precedence):
+   - `opencode.config.ts`
+   - `.opencode/transmute.config.json`
+   - `transmute.config.json`
+
+2. **Validate JSON syntax:**
+
+   ```bash
+   cat .opencode/transmute.config.json | jq .
+   ```
+
+3. **Check console for config source:**
+   ```
+   [transmute] Loaded config from: /repo/.opencode/transmute.config.json
+   ```
+
+### Invalid Configuration
+
+**Symptom:** Plugin fails to initialize with Zod error.
+
+**Cause:** Configuration values don't match schema.
+
+**Solutions:**
+
+1. **Check allowed values:**
+   - `terminal`: `"wezterm"`, `"tmux"`, `"kitty"`, `"none"`
+   - `defaultBranchType`: `"feat"`, `"fix"`, `"refactor"`, `"docs"`, `"chore"`, `"test"`
+
+2. **Validate programmatically:**
+
+   ```typescript
+   import { validateConfig } from "opencode-transmute";
+
+   const result = validateConfig(myConfig);
+   if (!result.success) {
+     console.error(result.error.issues);
+   }
+   ```
+
+## Manual Cleanup
+
+If things get into a bad state, here's how to clean up:
+
+```bash
+# 1. List all worktrees
+git worktree list
+
+# 2. Remove all non-main worktrees
+for wt in ./worktrees/*; do
+  git worktree remove "$wt" --force
+done
+
+# 3. Prune git worktree metadata
+git worktree prune
+
+# 4. Reset session state
+echo '{"sessions":[]}' > .opencode/transmute.sessions.json
+
+# 5. Delete orphan branches (optional)
+git branch | grep -v main | xargs git branch -D
+```
+
+## Getting Help
+
+If you're still stuck:
+
+1. **Check the logs** - the plugin logs useful information to console
+2. **Open an issue** on [GitHub](https://github.com/1001Josias/transmute/issues)
+3. **Include** your configuration, error message, and steps to reproduce

--- a/projects/blueprint-ai/opencode-transmute/tasks.md
+++ b/projects/blueprint-ai/opencode-transmute/tasks.md
@@ -528,31 +528,31 @@ Verificar que worktree pode ser removido corretamente.
 ## Task 10: Documentation
 
 - **id:** oc-trans-010
-- **status:** todo
+- **status:** done
 - **priority:** low
 - **description:** Documentar uso e configuração do plugin.
 - **dependencies:** oc-trans-007, oc-trans-008
 
 ### Subtasks
 
-#### [ ] README do app
+#### [x] Criar seção Plugins no docs
 
-- Overview do plugin
-- Como funciona no contexto do monorepo Transmute
-- Configuração básica
-- Exemplo de uso
+Nova seção `apps/docs/content/docs/plugins/` criada com:
 
-#### [ ] Documentação de API
+- `index.mdx` - Overview da seção de plugins
 
-- Tools disponíveis
-- Schemas de input/output
-- Configurações suportadas
+#### [x] Documentação do Plugin
 
-#### [ ] Troubleshooting
+Documentação completa em `apps/docs/content/docs/plugins/opencode-transmute/`:
 
-- WezTerm não encontrado
-- Erros comuns de Git
-- Como limpar worktrees manualmente
+- `index.mdx` - Overview, quick start, como funciona
+- `configuration.mdx` - Todas as opções de configuração com exemplos
+- `api.mdx` - Referência de API (tools, funções, schemas, erros)
+- `troubleshooting.mdx` - Guia de solução de problemas
+
+#### [x] Build do docs funcionando
+
+Verificado que `pnpm build` no apps/docs compila as novas páginas corretamente.
 
 ---
 


### PR DESCRIPTION
## Summary

- Implements Task 10 (oc-trans-010): Documentation for opencode-transmute plugin
- Creates new Plugins section in the docs site
- Adds comprehensive documentation for the plugin

## New Documentation Pages

### Plugins Section (`/docs/plugins`)
- Overview of plugin architecture
- How to create plugins

### OpenCode Transmute (`/docs/plugins/opencode-transmute`)

| Page | Description |
|------|-------------|
| **Overview** | Introduction, quick start, how it works |
| **Configuration** | All config options with examples |
| **API Reference** | Tools, functions, schemas, error classes |
| **Troubleshooting** | Common issues and solutions |

## Documentation Highlights

- **Quick Start Guide**: Install, configure, use in 3 steps
- **Visual Flow Diagram**: Shows the complete start-task flow
- **Configuration Examples**: Both `opencode.config.ts` and JSON formats
- **API Reference**: All exported functions and Zod schemas
- **Troubleshooting**: Solutions for terminal, git, session, and hook issues

## Build Verification

```
✓ Generating static pages (25/25)
```

All new pages compile successfully.