### PR TITLE
feat(wezterm): implement WezTerm integration

### DIFF
--- a/packages/opencode-transmute/src/adapters/terminal/index.ts
+++ b/packages/opencode-transmute/src/adapters/terminal/index.ts
@@ -1,2 +1,8 @@
+/**
+ * Terminal Adapters
+ *
+ * Re-exports all terminal adapter implementations.
+ */
+
 export * from "./types";
 export * from "./wezterm";

--- a/packages/opencode-transmute/src/adapters/terminal/types.ts
+++ b/packages/opencode-transmute/src/adapters/terminal/types.ts
@@ -1,1 +1,93 @@
-export {};
+/**
+ * Terminal Adapter Types
+ *
+ * Abstract interface for terminal integrations.
+ * Allows different terminal emulators to be used interchangeably.
+ */
+
+/**
+ * Options for opening a terminal session
+ */
+export interface OpenSessionOptions {
+  /** Working directory for the terminal */
+  cwd: string;
+  /** Commands to execute on session start */
+  commands?: string[];
+  /** Title for the terminal tab/window */
+  title?: string;
+  /** Environment variables to set */
+  env?: Record<string, string>;
+}
+
+/**
+ * Abstract terminal adapter interface
+ *
+ * Implementations should handle terminal-specific details
+ * for opening sessions, executing commands, etc.
+ */
+export interface TerminalAdapter {
+  /** Adapter name (e.g., "wezterm", "tmux") */
+  name: string;
+
+  /**
+   * Check if this terminal is available on the system
+   *
+   * @returns True if the terminal can be used
+   */
+  isAvailable(): Promise<boolean>;
+
+  /**
+   * Open a new terminal session
+   *
+   * @param options - Session options
+   */
+  openSession(options: OpenSessionOptions): Promise<void>;
+}
+
+/**
+ * Result of terminal availability check
+ */
+export interface TerminalAvailability {
+  /** Adapter name */
+  name: string;
+  /** Whether the terminal is available */
+  available: boolean;
+  /** Version if available */
+  version?: string;
+  /** Path to the executable */
+  path?: string;
+}
+
+/**
+ * Check availability of multiple terminal adapters
+ *
+ * @param adapters - Array of terminal adapters to check
+ * @returns Availability status for each adapter
+ */
+export async function checkTerminalAvailability(
+  adapters: TerminalAdapter[],
+): Promise<TerminalAvailability[]> {
+  return Promise.all(
+    adapters.map(async (adapter) => ({
+      name: adapter.name,
+      available: await adapter.isAvailable(),
+    })),
+  );
+}
+
+/**
+ * Get the first available terminal adapter
+ *
+ * @param adapters - Array of terminal adapters to check (in priority order)
+ * @returns First available adapter or undefined
+ */
+export async function getFirstAvailableTerminal(
+  adapters: TerminalAdapter[],
+): Promise<TerminalAdapter | undefined> {
+  for (const adapter of adapters) {
+    if (await adapter.isAvailable()) {
+      return adapter;
+    }
+  }
+  return undefined;
+}

--- a/packages/opencode-transmute/src/adapters/terminal/wezterm.test.ts
+++ b/packages/opencode-transmute/src/adapters/terminal/wezterm.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Tests for WezTerm Terminal Adapter
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { WezTermAdapter, createWezTermAdapter } from "./wezterm";
+import type { ExecResult } from "../../core/exec";
+import {
+  TerminalNotAvailableError,
+  TerminalSpawnError,
+  InvalidPathError,
+} from "../../core/errors";
+
+// Helper to create a properly typed mock exec function
+function createMockExec() {
+  return vi.fn<
+    [string, string[], { throwOnError?: boolean; cwd?: string }?],
+    Promise<ExecResult>
+  >();
+}
+
+describe("WezTermAdapter", () => {
+  describe("isAvailable", () => {
+    it("should return true when wezterm is installed", async () => {
+      const mockExec = createMockExec().mockResolvedValue({
+        stdout: "wezterm 20230712-072601-f4abf8fd\n",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      const adapter = new WezTermAdapter({ execFn: mockExec });
+      const result = await adapter.isAvailable();
+
+      expect(result).toBe(true);
+      expect(mockExec).toHaveBeenCalledWith("wezterm", ["--version"], {
+        throwOnError: false,
+      });
+    });
+
+    it("should return false when wezterm is not installed", async () => {
+      const mockExec = createMockExec().mockResolvedValue({
+        stdout: "",
+        stderr: "command not found: wezterm",
+        exitCode: 127,
+      });
+
+      const adapter = new WezTermAdapter({ execFn: mockExec });
+      const result = await adapter.isAvailable();
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false when exec throws an error", async () => {
+      const mockExec = createMockExec().mockRejectedValue(new Error("ENOENT"));
+
+      const adapter = new WezTermAdapter({ execFn: mockExec });
+      const result = await adapter.isAvailable();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getVersion", () => {
+    it("should return version string when wezterm is available", async () => {
+      const mockExec = createMockExec().mockResolvedValue({
+        stdout: "wezterm 20230712-072601-f4abf8fd\n",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      const adapter = new WezTermAdapter({ execFn: mockExec });
+      const version = await adapter.getVersion();
+
+      expect(version).toBe("20230712-072601-f4abf8fd");
+    });
+
+    it("should handle version output without 'wezterm' prefix", async () => {
+      const mockExec = createMockExec().mockResolvedValue({
+        stdout: "20240101-abcdef12\n",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      const adapter = new WezTermAdapter({ execFn: mockExec });
+      const version = await adapter.getVersion();
+
+      expect(version).toBe("20240101-abcdef12");
+    });
+
+    it("should return undefined when wezterm is not installed", async () => {
+      const mockExec = createMockExec().mockResolvedValue({
+        stdout: "",
+        stderr: "command not found",
+        exitCode: 127,
+      });
+
+      const adapter = new WezTermAdapter({ execFn: mockExec });
+      const version = await adapter.getVersion();
+
+      expect(version).toBeUndefined();
+    });
+
+    it("should return undefined when exec throws", async () => {
+      const mockExec = createMockExec().mockRejectedValue(new Error("ENOENT"));
+
+      const adapter = new WezTermAdapter({ execFn: mockExec });
+      const version = await adapter.getVersion();
+
+      expect(version).toBeUndefined();
+    });
+  });
+
+  describe("openSession", () => {
+    let mockExec: ReturnType<typeof createMockExec>;
+    let adapter: WezTermAdapter;
+
+    beforeEach(() => {
+      mockExec = createMockExec();
+      adapter = new WezTermAdapter({ execFn: mockExec });
+    });
+
+    it("should spawn a session with cwd", async () => {
+      // First call: isAvailable check
+      mockExec.mockResolvedValueOnce({
+        stdout: "wezterm 20230712\n",
+        stderr: "",
+        exitCode: 0,
+      });
+      // Second call: spawn
+      mockExec.mockResolvedValueOnce({
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await adapter.openSession({ cwd: "/path/to/worktree" });
+
+      expect(mockExec).toHaveBeenCalledTimes(2);
+      expect(mockExec).toHaveBeenLastCalledWith(
+        "wezterm",
+        ["cli", "spawn", "--cwd", "/path/to/worktree"],
+        { throwOnError: false },
+      );
+    });
+
+    it("should include title when provided", async () => {
+      mockExec.mockResolvedValueOnce({
+        stdout: "wezterm 20230712\n",
+        stderr: "",
+        exitCode: 0,
+      });
+      mockExec.mockResolvedValueOnce({
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await adapter.openSession({
+        cwd: "/path/to/worktree",
+        title: "My Task",
+      });
+
+      expect(mockExec).toHaveBeenLastCalledWith(
+        "wezterm",
+        [
+          "cli",
+          "spawn",
+          "--cwd",
+          "/path/to/worktree",
+          "--pane-title",
+          "My Task",
+        ],
+        { throwOnError: false },
+      );
+    });
+
+    it("should execute commands when provided", async () => {
+      mockExec.mockResolvedValueOnce({
+        stdout: "wezterm 20230712\n",
+        stderr: "",
+        exitCode: 0,
+      });
+      mockExec.mockResolvedValueOnce({
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await adapter.openSession({
+        cwd: "/path/to/worktree",
+        commands: ["pnpm install", "pnpm dev"],
+      });
+
+      expect(mockExec).toHaveBeenLastCalledWith(
+        "wezterm",
+        [
+          "cli",
+          "spawn",
+          "--cwd",
+          "/path/to/worktree",
+          "--",
+          "sh",
+          "-c",
+          "pnpm install && pnpm dev",
+        ],
+        { throwOnError: false },
+      );
+    });
+
+    it("should include all options together", async () => {
+      mockExec.mockResolvedValueOnce({
+        stdout: "wezterm 20230712\n",
+        stderr: "",
+        exitCode: 0,
+      });
+      mockExec.mockResolvedValueOnce({
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await adapter.openSession({
+        cwd: "/path/to/worktree",
+        title: "feat/add-login",
+        commands: ["opencode --session abc123"],
+      });
+
+      expect(mockExec).toHaveBeenLastCalledWith(
+        "wezterm",
+        [
+          "cli",
+          "spawn",
+          "--cwd",
+          "/path/to/worktree",
+          "--pane-title",
+          "feat/add-login",
+          "--",
+          "sh",
+          "-c",
+          "opencode --session abc123",
+        ],
+        { throwOnError: false },
+      );
+    });
+
+    it("should throw TerminalNotAvailableError when wezterm is not installed", async () => {
+      mockExec.mockResolvedValueOnce({
+        stdout: "",
+        stderr: "command not found",
+        exitCode: 127,
+      });
+
+      await expect(
+        adapter.openSession({ cwd: "/path/to/worktree" }),
+      ).rejects.toThrow(TerminalNotAvailableError);
+    });
+
+    it("should throw InvalidPathError when path does not exist", async () => {
+      mockExec.mockResolvedValueOnce({
+        stdout: "wezterm 20230712\n",
+        stderr: "",
+        exitCode: 0,
+      });
+      mockExec.mockResolvedValueOnce({
+        stdout: "",
+        stderr: "Error: No such file or directory",
+        exitCode: 1,
+      });
+
+      await expect(
+        adapter.openSession({ cwd: "/nonexistent/path" }),
+      ).rejects.toThrow(InvalidPathError);
+    });
+
+    it("should throw TerminalSpawnError for other spawn failures", async () => {
+      mockExec.mockResolvedValueOnce({
+        stdout: "wezterm 20230712\n",
+        stderr: "",
+        exitCode: 0,
+      });
+      mockExec.mockResolvedValueOnce({
+        stdout: "",
+        stderr: "Connection refused",
+        exitCode: 1,
+      });
+
+      await expect(
+        adapter.openSession({ cwd: "/path/to/worktree" }),
+      ).rejects.toThrow(TerminalSpawnError);
+    });
+
+    it("should wrap unexpected errors in TerminalSpawnError", async () => {
+      mockExec.mockResolvedValueOnce({
+        stdout: "wezterm 20230712\n",
+        stderr: "",
+        exitCode: 0,
+      });
+      mockExec.mockRejectedValueOnce(new Error("Unexpected error"));
+
+      await expect(
+        adapter.openSession({ cwd: "/path/to/worktree" }),
+      ).rejects.toThrow(TerminalSpawnError);
+    });
+  });
+
+  describe("createWezTermAdapter", () => {
+    it("should create a WezTermAdapter instance", () => {
+      const adapter = createWezTermAdapter();
+
+      expect(adapter).toBeInstanceOf(WezTermAdapter);
+      expect(adapter.name).toBe("wezterm");
+    });
+
+    it("should accept custom exec function", () => {
+      const mockExec = createMockExec();
+      const adapter = createWezTermAdapter({ execFn: mockExec });
+
+      expect(adapter).toBeInstanceOf(WezTermAdapter);
+    });
+  });
+
+  describe("adapter properties", () => {
+    it("should have name property set to 'wezterm'", () => {
+      const adapter = new WezTermAdapter();
+      expect(adapter.name).toBe("wezterm");
+    });
+  });
+});
+
+describe("Terminal error classes", () => {
+  describe("TerminalNotAvailableError", () => {
+    it("should include terminal name in message", () => {
+      const error = new TerminalNotAvailableError("wezterm");
+
+      expect(error.message).toContain("wezterm");
+      expect(error.message).toContain("not available");
+      expect(error.terminal).toBe("wezterm");
+      expect(error.code).toBe("NOT_AVAILABLE");
+    });
+  });
+
+  describe("TerminalSpawnError", () => {
+    it("should include terminal name and reason in message", () => {
+      const error = new TerminalSpawnError("wezterm", "Connection refused");
+
+      expect(error.message).toContain("wezterm");
+      expect(error.message).toContain("Connection refused");
+      expect(error.terminal).toBe("wezterm");
+      expect(error.reason).toBe("Connection refused");
+      expect(error.code).toBe("SPAWN_FAILED");
+    });
+  });
+
+  describe("InvalidPathError", () => {
+    it("should include path in message", () => {
+      const error = new InvalidPathError("/nonexistent/path");
+
+      expect(error.message).toContain("/nonexistent/path");
+      expect(error.path).toBe("/nonexistent/path");
+      expect(error.code).toBe("INVALID_PATH");
+    });
+  });
+});

--- a/packages/opencode-transmute/src/adapters/terminal/wezterm.ts
+++ b/packages/opencode-transmute/src/adapters/terminal/wezterm.ts
@@ -1,1 +1,177 @@
-export {};
+/**
+ * WezTerm Terminal Adapter
+ *
+ * Integration with WezTerm terminal emulator.
+ * Uses `wezterm cli` commands to spawn new panes/tabs.
+ */
+
+import { exec } from "../../core/exec";
+import {
+  TerminalNotAvailableError,
+  TerminalSpawnError,
+  InvalidPathError,
+} from "../../core/errors";
+import type { TerminalAdapter, OpenSessionOptions } from "./types";
+
+/**
+ * Options for WezTerm adapter
+ */
+export interface WezTermAdapterOptions {
+  /**
+   * Custom exec function for testing
+   */
+  execFn?: typeof exec;
+}
+
+/**
+ * WezTerm terminal adapter implementation
+ */
+export class WezTermAdapter implements TerminalAdapter {
+  name = "wezterm";
+  private execFn: typeof exec;
+
+  constructor(options: WezTermAdapterOptions = {}) {
+    this.execFn = options.execFn ?? exec;
+  }
+
+  /**
+   * Check if WezTerm is available on the system
+   *
+   * Looks for `wezterm` in PATH by running `wezterm --version`
+   */
+  async isAvailable(): Promise<boolean> {
+    try {
+      const result = await this.execFn("wezterm", ["--version"], {
+        throwOnError: false,
+      });
+      return result.exitCode === 0;
+    } catch {
+      // Command not found or other error
+      return false;
+    }
+  }
+
+  /**
+   * Get WezTerm version information
+   *
+   * @returns Version string or undefined if not available
+   */
+  async getVersion(): Promise<string | undefined> {
+    try {
+      const result = await this.execFn("wezterm", ["--version"], {
+        throwOnError: false,
+      });
+
+      if (result.exitCode !== 0) {
+        return undefined;
+      }
+
+      // Parse version from output like "wezterm 20230712-072601-f4abf8fd"
+      const output = result.stdout.trim();
+      const match = output.match(/wezterm\s+(.+)/i);
+      return match ? match[1] : output;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Open a new terminal session in WezTerm
+   *
+   * Uses `wezterm cli spawn` to create a new pane in the current window.
+   * If commands are provided, they are executed in sequence.
+   *
+   * @param options - Session options
+   * @throws TerminalNotAvailableError if WezTerm is not installed
+   * @throws InvalidPathError if the cwd path is invalid
+   * @throws TerminalSpawnError if spawning the session fails
+   */
+  async openSession(options: OpenSessionOptions): Promise<void> {
+    // Verify WezTerm is available
+    const available = await this.isAvailable();
+    if (!available) {
+      throw new TerminalNotAvailableError("wezterm");
+    }
+
+    // Build the spawn command
+    const args = this.buildSpawnArgs(options);
+
+    try {
+      const result = await this.execFn("wezterm", args, {
+        throwOnError: false,
+      });
+
+      if (result.exitCode !== 0) {
+        // Check for common error patterns
+        const stderr = result.stderr.toLowerCase();
+
+        if (
+          stderr.includes("no such file or directory") ||
+          stderr.includes("directory does not exist")
+        ) {
+          throw new InvalidPathError(options.cwd);
+        }
+
+        throw new TerminalSpawnError("wezterm", result.stderr || result.stdout);
+      }
+    } catch (error) {
+      // Re-throw our custom errors
+      if (
+        error instanceof TerminalNotAvailableError ||
+        error instanceof InvalidPathError ||
+        error instanceof TerminalSpawnError
+      ) {
+        throw error;
+      }
+
+      // Wrap unexpected errors
+      throw new TerminalSpawnError(
+        "wezterm",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  /**
+   * Build wezterm cli spawn arguments
+   *
+   * @param options - Session options
+   * @returns Array of command arguments
+   */
+  private buildSpawnArgs(options: OpenSessionOptions): string[] {
+    const args: string[] = ["cli", "spawn"];
+
+    // Set working directory
+    args.push("--cwd", options.cwd);
+
+    // Set pane title if provided
+    if (options.title) {
+      args.push("--pane-title", options.title);
+    }
+
+    // If commands are provided, join them and pass as the program to run
+    if (options.commands && options.commands.length > 0) {
+      // Use -- to separate wezterm args from the command
+      args.push("--");
+
+      // Combine commands with && to run sequentially
+      // Use sh -c to execute the combined command
+      const combinedCommand = options.commands.join(" && ");
+      args.push("sh", "-c", combinedCommand);
+    }
+
+    return args;
+  }
+}
+
+/**
+ * Create a WezTerm adapter instance
+ *
+ * @param options - Adapter options
+ * @returns WezTerm adapter
+ */
+export function createWezTermAdapter(
+  options?: WezTermAdapterOptions,
+): TerminalAdapter {
+  return new WezTermAdapter(options);
+}

--- a/packages/opencode-transmute/src/core/errors.ts
+++ b/packages/opencode-transmute/src/core/errors.ts
@@ -131,3 +131,78 @@ export class ExecError extends WorktreeError {
     this.exitCode = exitCode;
   }
 }
+
+/**
+ * Error codes for terminal operations
+ */
+export const TerminalErrorCode = {
+  NOT_AVAILABLE: "NOT_AVAILABLE",
+  SPAWN_FAILED: "SPAWN_FAILED",
+  INVALID_PATH: "INVALID_PATH",
+} as const;
+
+export type TerminalErrorCodeType =
+  (typeof TerminalErrorCode)[keyof typeof TerminalErrorCode];
+
+/**
+ * Base error class for terminal operations
+ */
+export class TerminalError extends Error {
+  readonly code: TerminalErrorCodeType;
+
+  constructor(message: string, code: TerminalErrorCodeType) {
+    super(message);
+    this.name = "TerminalError";
+    this.code = code;
+  }
+}
+
+/**
+ * Thrown when a terminal emulator is not available
+ */
+export class TerminalNotAvailableError extends TerminalError {
+  readonly terminal: string;
+
+  constructor(terminal: string) {
+    super(
+      `Terminal '${terminal}' is not available. Please install it or check your PATH.`,
+      TerminalErrorCode.NOT_AVAILABLE,
+    );
+    this.name = "TerminalNotAvailableError";
+    this.terminal = terminal;
+  }
+}
+
+/**
+ * Thrown when spawning a terminal session fails
+ */
+export class TerminalSpawnError extends TerminalError {
+  readonly terminal: string;
+  readonly reason: string;
+
+  constructor(terminal: string, reason: string) {
+    super(
+      `Failed to spawn terminal session in '${terminal}': ${reason}`,
+      TerminalErrorCode.SPAWN_FAILED,
+    );
+    this.name = "TerminalSpawnError";
+    this.terminal = terminal;
+    this.reason = reason;
+  }
+}
+
+/**
+ * Thrown when the working directory path is invalid
+ */
+export class InvalidPathError extends TerminalError {
+  readonly path: string;
+
+  constructor(path: string) {
+    super(
+      `Invalid path: '${path}'. The directory does not exist or is not accessible.`,
+      TerminalErrorCode.INVALID_PATH,
+    );
+    this.name = "InvalidPathError";
+    this.path = path;
+  }
+}

--- a/projects/blueprint-ai/opencode-transmute/tasks.md
+++ b/projects/blueprint-ai/opencode-transmute/tasks.md
@@ -279,7 +279,7 @@ Cobrir casos com vitest:
 
 ### Subtasks
 
-#### [ ] Definir interface abstrata de terminal
+#### [x] Definir interface abstrata de terminal
 
 Interface já definida em `types.ts`:
 
@@ -298,11 +298,11 @@ interface OpenSessionOptions {
 }
 ```
 
-#### [ ] Verificar disponibilidade do WezTerm
+#### [x] Verificar disponibilidade do WezTerm
 
 Implementado `isAvailable()` que executa `wezterm --version` e verifica exit code.
 
-#### [ ] Implementar openSession para WezTerm
+#### [x] Implementar openSession para WezTerm
 
 Implementado usando `wezterm cli spawn --cwd <path>`:
 
@@ -310,7 +310,7 @@ Implementado usando `wezterm cli spawn --cwd <path>`:
 - Suporta execução de comandos via `sh -c`
 - Verifica disponibilidade antes de abrir
 
-#### [ ] Tratamento de erros
+#### [x] Tratamento de erros
 
 Novas classes de erro em `errors.ts`:
 
@@ -318,7 +318,7 @@ Novas classes de erro em `errors.ts`:
 - `TerminalSpawnError` - Falha ao abrir sessão
 - `InvalidPathError` - Path inválido
 
-#### [ ] Adicionar testes unitários
+#### [x] Adicionar testes unitários
 
 21 testes criados em `wezterm.test.ts` cobrindo:
 


### PR DESCRIPTION
Implements Task 5: WezTerm Integration.\n\n- Adds `WezTermAdapter` implementing  interface.\n- Supports spawning sessions with title, cwd, and commands.\n- Checks WezTerm availability via version command.\n- Validates WezTerm 100% with tests.